### PR TITLE
Bug fix in SmartFormatter.AddExtensions method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Thumbnails created by windows
+Thumbs.db
+# Files created by Visual Studio
+*.aps
+*.cache
+*.ilk
+*.lib
+*.log
+*.ncb
+*.obj
+*.pch
+*.sbr
+*.suo
+*.tlb
+*.tlh
+*.user
+*_i.c
+*_p.c
+obj/
+[Bb]in/
+[Ee]rror[Ll]ogs*
+[Tt]est[Rr]esult*
+_ReSharper*/
+# Files created by Visual Studio 6
+*.*[Ss][Cc][Cc]
+*.vbw
+*.tmp.vbp
+# Other
+*.bak
+*.tmp

--- a/src/SmartFormat.Tests/Extensions/UserExtensionTests.cs
+++ b/src/SmartFormat.Tests/Extensions/UserExtensionTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Globalization;
+using NUnit.Framework;
+using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Output;
+using SmartFormat.Core.Parsing;
+
+namespace SmartFormat.Tests.Extensions
+{
+    [TestFixture]
+    public class UserExtensionTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            Smart.Default.ClearUserExtensions();
+        }
+
+        [Test]
+        public void Test_Custom_Formatter()
+        {
+            //arrange
+            var guid = new Guid("4f86ca67-94c2-4ce1-b79d-c4ed063d3a8e");
+            Smart.Default.AddUserExtensions(new CustomGuidFormatter());
+
+            //act
+            var formatted = Smart.Format(CultureInfo.InvariantCulture, "{0}, {1}", guid, new DateTime(2012, 08, 24));
+
+            Assert.That(formatted, Is.EqualTo("4f86ca..., 08/24/2012 00:00:00"));
+        }
+
+        [Test]
+        public void Test_Clear_Custom_Formatters()
+        {
+            //arrange
+            var guid = new Guid("4f86ca67-94c2-4ce1-b79d-c4ed063d3a8e");
+            Smart.Default.AddUserExtensions(new CustomGuidFormatter());
+            Smart.Default.ClearUserExtensions();
+
+            //act
+            var formatted = Smart.Format(CultureInfo.InvariantCulture, "{0}, {1}", guid, new DateTime(2012, 08, 24));
+
+            Assert.That(formatted, Is.EqualTo("4f86ca67-94c2-4ce1-b79d-c4ed063d3a8e, 08/24/2012 00:00:00"));
+        }
+    }
+
+    class CustomGuidFormatter : IFormatter
+    {
+        public void EvaluateFormat(object current, Format format, ref bool handled, IOutput output, FormatDetails formatDetails)
+        {
+            if (!(current is Guid))
+                return;
+
+            var guid = (Guid)current;
+
+            output.Write(guid.ToString().Substring(0, 6), formatDetails);
+            output.Write("...", formatDetails);
+
+            handled = true;
+        }
+    }
+}

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -31,7 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.5.5.10112, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" />
+    <Reference Include="nunit.framework, Version=2.5.5.10112, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -44,6 +46,7 @@
     </Compile>
     <Compile Include="Extensions\ListFormatterTests.cs" />
     <Compile Include="CodeProjectExampleTests.cs" />
+    <Compile Include="Extensions\UserExtensionTests.cs" />
     <Compile Include="TestUtils\ArgumentValidator.cs" />
     <Compile Include="TestUtils\EnumerableExtensions.cs" />
     <Compile Include="TestUtils\ExceptionCollection.cs" />

--- a/src/SmartFormat/Properties/AssemblyInfo.cs
+++ b/src/SmartFormat/Properties/AssemblyInfo.cs
@@ -26,3 +26,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("SmartFormat.Tests")]


### PR DESCRIPTION
- Fixed bug in AddExtensions.cs - adding a custom extension was not working.
- Introduced AddUserExtensions and ClearUserExtensions methods
- Changed accessibility of SourceExtensions and FormatterExtensions in order to enforce encapsulation
- Added .gitignore file
