### PR TITLE
Added error mode that leaves invalid tokens as-is

### DIFF
--- a/src/SmartFormat.Tests/Core/CoreTests.cs
+++ b/src/SmartFormat.Tests/Core/CoreTests.cs
@@ -239,5 +239,22 @@ namespace SmartFormat.Tests
 
             formatter.Test("--{0}--{0:ZZZZ}--", errorArgs, "------");
         }
+
+        [Test]
+        public void Formatter_Maintains_Tokens()
+        {
+            var formatter = Smart.CreateDefaultSmartFormat();
+            formatter.ErrorAction = ErrorAction.MaintainTokens;
+
+            formatter.Test("--{0}--{0:ZZZZ}--", errorArgs, "--{0}--{0:ZZZZ}--");
+        }
+
+        [Test]
+        public void Formatter_Maintains_Object_Tokens()
+        {
+            var formatter = Smart.CreateDefaultSmartFormat();
+            formatter.ErrorAction = ErrorAction.MaintainTokens;
+            formatter.Test("--{Object.Thing}--", errorArgs, "--{Object.Thing}--");
+        }
     }
 }

--- a/src/SmartFormat/Core/ErrorAction.cs
+++ b/src/SmartFormat/Core/ErrorAction.cs
@@ -12,7 +12,10 @@
         OutputErrorInResult, 
         
         /// <summary>Ignores errors and tries to output the data anyway</summary>
-        Ignore
+        Ignore,
+        
+        /// <summary>Leaves invalid tokens unmodified in the text.</summary>
+        MaintainTokens
     }
 
 }

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -222,6 +222,9 @@ namespace SmartFormat
                     output.Write(issue, formatDetails);
                     formatDetails.FormatError = null;
                     break;
+                case ErrorAction.MaintainTokens:
+                    output.Write(formatDetails.Placeholder.Text, formatDetails);
+                    break;
             }
         }
         private void FormatError(FormatItem errorItem, Exception innerException, int startIndex, IOutput output, FormatDetails formatDetails)
@@ -236,6 +239,9 @@ namespace SmartFormat
                     formatDetails.FormatError = new FormatException(errorItem, innerException, startIndex);
                     output.Write(innerException.Message, formatDetails);
                     formatDetails.FormatError = null;
+                    break;
+                case ErrorAction.MaintainTokens:
+                    output.Write(formatDetails.Placeholder.Text, formatDetails);
                     break;
             }
         }


### PR DESCRIPTION
Adding this error mode allows users to format a message with multiple passes. This will allow for multiple source objects to be applied to a message.

I've included unit tests. Let me know if you'd like anything changed.
