### PR TITLE
Add support for expando objects

### DIFF
--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -31,7 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.5.5.10112, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" />
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -70,6 +72,9 @@
       <Project>{83A94F48-8529-4A41-B5E1-1684827180DF}</Project>
       <Name>SmartFormat</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/SmartFormat.Tests/packages.config
+++ b/src/SmartFormat.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net35" />
+</packages>

--- a/src/SmartFormat/Extensions/DictionarySource.cs
+++ b/src/SmartFormat/Extensions/DictionarySource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Parsing;
 
@@ -16,12 +17,21 @@ namespace SmartFormat.Extensions
 
         public void EvaluateSelector(object current, Selector selector, ref bool handled, ref object result, FormatDetails formatDetails)
         {
-            // See if current is a IDictionary and contains the selector:
+            // See if current is a IDictionary and contains the selector
             var dict = current as IDictionary;
-
             if (dict != null && dict.Contains(selector.Text))
             {
                 result = dict[selector.Text];
+                handled = true;
+                return;
+            }
+
+            // See if current is an IDictionary<string, object> (also an "expando" object) 
+            // and contains the selector.
+            var genericDictionary = current as IDictionary<string, object>;
+            if (genericDictionary != null && genericDictionary.ContainsKey(selector.Text))
+            {
+                result = genericDictionary[selector.Text];
                 handled = true;
             }
         }

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\SmartFormat.Tests\packages.config" />
+</repositories>


### PR DESCRIPTION
I made two small changes:
- Added support for expando objects (which implement IDictionary<string, object> but not IDictionary)
- Switched nunit.framework to pull from nuget (otherwise, you have to have installed the specific version of nunit, which is unlikely).

I wasn't able to figure out an easy way to write a unit test for the new generic `IDictionary` support, as .NET 3.5 doesn't have expando objects, and hence the only easily available implementation of `IDictionary<string,object>` is the `Dictionary<string, object>` that you're already using in your tests. But take a look at the code and see if it makes sense to you.
