### PR TITLE
Added overloads for the SmartFormatter.AddExtensions function ...

### DIFF
--- a/src/SmartFormat.Tests/CodeProjectExampleTests.cs
+++ b/src/SmartFormat.Tests/CodeProjectExampleTests.cs
@@ -464,9 +464,8 @@ namespace SmartFormat.Tests
         {
             var Smart = new SmartFormatter();
             Smart.Parser.UseAlternativeEscapeChar('\\');
-            Smart.AddExtensions(
-                new DefaultFormatter(), 
-                new DefaultSource(Smart));
+            Smart.AddExtensions(new DefaultFormatter());
+            Smart.AddExtensions(new DefaultSource(Smart));
 
             var args = new object[] { "Zero", "One", "Two", 3 };
 

--- a/src/SmartFormat.Tests/PerformanceTests.cs
+++ b/src/SmartFormat.Tests/PerformanceTests.cs
@@ -56,7 +56,8 @@ namespace SmartFormat.Tests
             FormatCache cache = null;
             FormatCache cache2 = null;
             var NoExtensions = new SmartFormatter();
-            NoExtensions.AddExtensions(new DefaultFormatter(), new DefaultSource(NoExtensions));
+            NoExtensions.AddExtensions(new DefaultSource(NoExtensions));
+            NoExtensions.AddExtensions(new DefaultFormatter());
 
             var formatters = new[] {
                 new {

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -66,15 +66,21 @@ namespace SmartFormat
 			// Add all extensions:
 			// Note, the order is important; the extensions
 			// will be executed in this order:
+
+			var listFormatter = new ListFormatter(result);
+			
 			result.AddExtensions(
-				new ListFormatter(result),
-				new PluralLocalizationFormatter("en"),
-				new ConditionalFormatter(),
-				new TimeFormatter("en"),
+				(ISource)listFormatter,
 				new ReflectionSource(result),
 				new DictionarySource(result),
 				// These default extensions reproduce the String.Format behavior:
-				new DefaultSource(result),
+				new DefaultSource(result)
+				);
+			result.AddExtensions(
+				(IFormatter)listFormatter,
+				new PluralLocalizationFormatter("en"),
+				new ConditionalFormatter(),
+				new TimeFormatter("en"),
 				new DefaultFormatter()
 				);
 

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -40,29 +40,59 @@ namespace SmartFormat
 
         public List<ISource> SourceExtensions { get; private set; }
         public List<IFormatter> FormatterExtensions { get; private set; }
+
+		/// <summary>
+		/// Adds each extensions to this formatter.
+		/// Each extension must implement ISource, IFormatter, or both.
+		/// 
+		/// An exception will be thrown if the extension doesn't implement those interfaces.
+		/// </summary>
+		/// <param name="extensions"></param>
+		[Obsolete("Please use the specific overloads of AddExtensions().")]
+		public void AddExtensions(params object[] extensions)
+		{
+			foreach (var extension in extensions)
+			{
+				// We need to filter each extension to the correct list:
+				var source = extension as ISource;
+				var formatter = extension as IFormatter;
+
+				// If this object ISN'T a extension, throw an exception:
+				if (source == null && formatter == null)
+					throw new ArgumentException(string.Format("{0} does not implement ISource nor IFormatter.", extension.GetType().FullName), "extensions");
+
+				if (source != null)
+					SourceExtensions.Add(source);
+				if (formatter != null)
+					FormatterExtensions.Add(formatter);
+			}
+		}
+
         /// <summary>
         /// Adds each extensions to this formatter.
-        /// Each extension must implement ISource, IFormatter, or both.
-        /// 
-        /// An exception will be thrown if the extension doesn't implement those interfaces.
+        /// Each extension must implement ISource.
         /// </summary>
-        /// <param name="extensions"></param>
-        public void AddExtensions(params object[] extensions)
+        /// <param name="sourceExtensions"></param>
+		public void AddExtensions(params ISource[] sourceExtensions)
         {
-            foreach (var extension in extensions)
+            foreach (var extension in sourceExtensions)
             {
-                // We need to filter each extension to the correct list:
-                var source = extension as ISource;
-                var formatter = extension as IFormatter;
+	            if (extension != null)
+                    SourceExtensions.Add(extension);
+            }
+        }
 
-                // If this object ISN'T a extension, throw an exception:
-                if (source == null && formatter == null)
-                    throw new ArgumentException(string.Format("{0} does not implement ISource nor IFormatter.", extension.GetType().FullName), "extensions");
-
-                if (source != null)
-                    SourceExtensions.Add(source);
-                if (formatter != null)
-                    FormatterExtensions.Add(formatter);
+        /// <summary>
+        /// Adds each extensions to this formatter.
+        /// Each extension must implement IFormatter.
+        /// </summary>
+        /// <param name="formatterExtensions"></param>
+        public void AddExtensions(params IFormatter[] formatterExtensions)
+        {
+            foreach (var extension in formatterExtensions)
+            {
+	            if (extension != null)
+                    FormatterExtensions.Add(extension);
             }
         }
 


### PR DESCRIPTION
...to accept explicitly ISource or IFormatter instead of a mixture of both.

Marked the old method SmartFormatter.AddExtensions(params object) as obsolete and removed all usages.

Reference: #17 
