### PR TITLE
Makes sure that substring outputs the entire string (or what's left of it), instead of "", if the specified length is to great.

### DIFF
--- a/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
@@ -1,16 +1,16 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SmartFormat.Tests.Extensions
 {
     [TestFixture]
     public class SubStringFormatterTests
     {
-        private List<object> _people;
-        private SmartFormatter _smart;
+        private readonly List<object> _people;
+        private readonly SmartFormatter _smart;
 
         public SubStringFormatterTests()
         {
@@ -46,6 +46,12 @@ namespace SmartFormat.Tests.Extensions
         public void StartPositionAndLengthLongerThanString()
         {
             Assert.AreEqual(string.Empty, _smart.Format("{Name:substr(999,1)}", _people.First()));
+        }
+
+        [Test]
+        public void LengthLongerThanString()
+        {
+            Assert.AreEqual("Long John", _smart.Format("{Name:substr(0,999)}", _people.First()));
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
@@ -51,7 +51,16 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void LengthLongerThanString()
         {
+            var formatter = _smart.GetFormatterExtension<SubStringFormatter>()!;
+            var behavior = formatter.OutOfRangeBehavior;
+
+            formatter.OutOfRangeBehavior = SubStringFormatter.SubStringOutOfRangeBehavior.ReturnStartIndexToEndOfString;
             Assert.AreEqual("Long John", _smart.Format("{Name:substr(0,999)}", _people.First()));
+            
+            formatter.OutOfRangeBehavior = SubStringFormatter.SubStringOutOfRangeBehavior.ReturnEmptyString;
+            Assert.AreEqual(string.Empty, _smart.Format("{Name:substr(0,999)}", _people.First()));
+
+            formatter.OutOfRangeBehavior = behavior;
         }
 
         [Test]

--- a/src/SmartFormat/Extensions/SubStringFormatter.cs
+++ b/src/SmartFormat/Extensions/SubStringFormatter.cs
@@ -27,6 +27,12 @@ namespace SmartFormat.Extensions
         /// </summary>
         public string NullDisplayString { get; set; } = "(null)";
 
+
+        /// <summary>
+        /// Get or set the behavior for when startindex and/or length is too great, defaults to SubStringOutOfRangeBehavior.ReturnEmptyString.
+        /// </summary>
+        public SubStringOutOfRangeBehavior OutOfRangeBehavior { get; set; } = SubStringOutOfRangeBehavior.ReturnEmptyString;
+
         /// <summary>
         /// Tries to process the given <see cref="IFormattingInfo"/>.
         /// </summary>
@@ -52,12 +58,20 @@ namespace SmartFormat.Extensions
                 startPos = currentValue.Length;
             if (length < 0)
                 length = currentValue.Length - startPos + length;
-            if (startPos > currentValue.Length)
-                startPos = currentValue.Length;
 
-            if (startPos + length > currentValue.Length)
-                length = (currentValue.Length - startPos);
-
+            switch(OutOfRangeBehavior)
+            {
+                case SubStringOutOfRangeBehavior.ReturnEmptyString:
+                    if (startPos + length > currentValue.Length)
+                        length = 0;
+                    break;
+                case SubStringOutOfRangeBehavior.ReturnStartIndexToEndOfString:
+                    if (startPos > currentValue.Length)
+                        startPos = currentValue.Length;
+                    if (startPos + length > currentValue.Length)
+                        length = (currentValue.Length - startPos);
+                    break;
+            }
 
             var substring = parameters.Length > 1
                 ? currentValue.Substring(startPos, length)
@@ -66,6 +80,25 @@ namespace SmartFormat.Extensions
             formattingInfo.Write(substring);
 
             return true;
+        }
+
+        /// <summary>
+        /// Specify behavior when startindex and/or length is out of range
+        /// </summary>
+        public enum SubStringOutOfRangeBehavior
+        {
+            /// <summary>
+            /// Returns string.Empty
+            /// </summary>
+            ReturnEmptyString,
+            /// <summary>
+            /// Returns the remainder of the string, starting at StartIndex
+            /// </summary>
+            ReturnStartIndexToEndOfString,
+            /// <summary>
+            /// Throws OutOfRangeException
+            /// </summary>
+            ThrowException
         }
     }
 }

--- a/src/SmartFormat/Extensions/SubStringFormatter.cs
+++ b/src/SmartFormat/Extensions/SubStringFormatter.cs
@@ -52,8 +52,13 @@ namespace SmartFormat.Extensions
                 startPos = currentValue.Length;
             if (length < 0)
                 length = currentValue.Length - startPos + length;
+            if (startPos > currentValue.Length)
+                startPos = currentValue.Length;
+
             if (startPos + length > currentValue.Length)
-                length = 0;
+                length = (currentValue.Length - startPos);
+
+
             var substring = parameters.Length > 1
                 ? currentValue.Substring(startPos, length)
                 : currentValue.Substring(startPos);


### PR DESCRIPTION
if specified length is longer than input length, set length to the maximum possible length

fixes #141

```	
var people = new List<object>
{new {Name = "Long John", City = "New York"}, new {Name = "Short Mary", City = "Massachusetts"},};

Smart.Format("{Name:substr(5)}", people.First());
// result: "John"

Smart.Format("{City:substr(0,3)}", people.First());
// result: "New"

Smart.Format("{City:substr(999,0)}", people.First());
// result: ""

Smart.Format("{City:substr(0,999)}", people.First());
// result: "New York"
```