### PR TITLE
Fix parsing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 **SmartFormat** is a **string composition** library written in C# which is basically compatible with string.Format. More than that **SmartFormat** can format data with named placeholders, lists, pluralization and other smart extensions.
 
 ### Supported Frameworks
-* .Net Framework 4.6.1, 4.6.2, 4.7.2 and 4.8
-* .Net Standard 2.0 and 2.1
-* .Net 5.0
+* .Net Framework 4.6.1 and later
+* .Net Standard 2.0 and later, including .Net 5.0
  
 ### Get started
 [![NuGet](https://img.shields.io/nuget/v/SmartFormat.Net.svg)](https://www.nuget.org/packages/SmartFormat.Net/) Install the NuGet package
@@ -30,7 +29,6 @@ We have started to think about a new version of ```SmartFormat.Net``` and **woul
 * Make caching of ```Parser.ParseFormat``` results the standard behavior
 * Performance improvements
 *  less generated garbage 
-* Support for Net 5.0
 * Remove ```public``` properties/methods which should better be ```internal``` or even ```privat```
 * Upgrade the project to C# 8 with nullable reference types included
 * Code clean-up: Make use of current C# features, add missing comments

--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -14,7 +14,7 @@ namespace SmartFormat.Tests.Core
         [Test]
         public void TestParser()
         {
-            var parser = new SmartFormatter() {Settings = { ParseErrorAction = ErrorAction.ThrowError}}.Parser;
+            var parser = new SmartFormatter {Settings = { ParseErrorAction = ErrorAction.ThrowError}}.Parser;
             parser.AddAlphanumericSelectors();
             parser.AddAdditionalSelectorChars("_");
             parser.AddOperators(".");
@@ -35,32 +35,26 @@ namespace SmartFormat.Tests.Core
             results.TryAll(r => Assert.AreEqual(r.format, r.parsed.ToString())).ThrowIfNotEmpty();
         }
 
-        [Test]
-        public void Parser_Throws_Exceptions()
+        [TestCase("{")]
+        [TestCase("{0")]
+        [TestCase("}")]
+        [TestCase("0}")]
+        [TestCase("{{{")]
+        [TestCase("}}}")]
+        [TestCase("{.}")]
+        [TestCase("{.:}")]
+        [TestCase("{..}")]
+        [TestCase("{..:}")]
+        [TestCase("{0.}")]
+        [TestCase("{0.:}")]
+        public void Parser_Throws_Exceptions(string format)
         {
             // Let's set the "ErrorAction" to "Throw":
             var formatter = Smart.CreateDefaultSmartFormat();
             formatter.Settings.ParseErrorAction = ErrorAction.ThrowError;
 
             var args = new object[] { TestFactory.GetPerson() };
-            var invalidFormats = new[] {
-                "{",
-                "{0",
-                "}",
-                "0}",
-                "{{{",
-                "}}}",
-                "{.}",
-                "{.:}",
-                "{..}",
-                "{..:}",
-                "{0.}",
-                "{0.:}",
-            };
-            foreach (var format in invalidFormats)
-            {
-                Assert.Throws<ParsingErrors>(() => formatter.Test(format, args, "Error"));
-            }
+            Assert.Throws<ParsingErrors>(() => formatter.Test(format, args, "Error"));
         }
 
         [Test]
@@ -119,42 +113,191 @@ namespace SmartFormat.Tests.Core
         [Test]
         public void Parser_Error_Action_Ignore()
         {
-            var invalidTemplate = "Hello, I'm {Name from {City}";
+            //                     | Literal  | Erroneous     | | Okay |  
+            var invalidTemplate = "Hello, I'm {Name from {City} {Street}";
 
             var smart = Smart.CreateDefaultSmartFormat();
             smart.Settings.ParseErrorAction = ErrorAction.Ignore;
-
-            var result = smart.Format(invalidTemplate, new { Name = "John", City = "Oklahoma" });
-
-            Assert.AreEqual(string.Empty, result);
+            
+            var parser = GetRegularParser();
+            parser.Settings.ParseErrorAction = ErrorAction.Ignore;
+            var parsed = parser.ParseFormat(invalidTemplate, new[] { Guid.NewGuid().ToString("N") });
+            
+            Assert.That(parsed.Items.Count, Is.EqualTo(4), "Number of parsed items");
+            Assert.That(parsed.Items[0].RawText, Is.EqualTo("Hello, I'm "), "Literal text");
+            Assert.That(parsed.Items[1].RawText, Is.EqualTo(string.Empty), "Erroneous placeholder");
+            Assert.That(parsed.Items[2].RawText, Is.EqualTo(" "));
+            Assert.That(parsed.Items[3], Is.TypeOf(typeof(Placeholder)));
+            Assert.That(parsed.Items[3].RawText, Does.Contain("{Street}"), "Correct placeholder");
         }
 
         [Test]
         public void Parser_Error_Action_MaintainTokens()
         {
-            var invalidTemplate = "Hello, I'm {Name from {City}";
+            //                     | Literal  | Erroneous     | | Okay |  
+            var invalidTemplate = "Hello, I'm {Name from {City} {Street}";
+            
+            var parser = GetRegularParser();
+            parser.Settings.ParseErrorAction = ErrorAction.MaintainTokens;
+            var parsed = parser.ParseFormat(invalidTemplate, new[] { Guid.NewGuid().ToString("N") });
 
-            var smart = Smart.CreateDefaultSmartFormat();
-            smart.Settings.ParseErrorAction = ErrorAction.MaintainTokens;
-
-            var result = smart.Format(invalidTemplate, new { Name = "John", City = "Oklahoma" });
-
-            Assert.AreEqual("Hello, I'm {Name from {City}", result);
+            Assert.That(parsed.Items.Count, Is.EqualTo(4), "Number of parsed items");
+            Assert.That(parsed.Items[0].RawText, Is.EqualTo("Hello, I'm "));
+            Assert.That(parsed.Items[1].RawText, Is.EqualTo("{Name from {City}"));
+            Assert.That(parsed.Items[2].RawText, Is.EqualTo(" "));
+            Assert.That(parsed.Items[3], Is.TypeOf(typeof(Placeholder)));
+            Assert.That(parsed.Items[3].RawText, Does.Contain("{Street}"));
         }
 
         [Test]
         public void Parser_Error_Action_OutputErrorInResult()
         {
+            //                     | Literal  | Erroneous     |
             var invalidTemplate = "Hello, I'm {Name from {City}";
+            
+            var parser = GetRegularParser();
+            parser.Settings.ParseErrorAction = ErrorAction.OutputErrorInResult;
+            var parsed = parser.ParseFormat(invalidTemplate, new[] { Guid.NewGuid().ToString("N") });
 
-            var smart = Smart.CreateDefaultSmartFormat();
-            smart.Settings.ParseErrorAction = ErrorAction.OutputErrorInResult;
+            Assert.That(parsed.Items.Count, Is.EqualTo(1));
+            Assert.That(parsed.Items[0].RawText, Does.StartWith("The format string has 3 issues"));
+        }
 
-            var result = smart.Format(invalidTemplate, new { Name = "John", City = "Oklahoma" });
+        /// <summary>
+        /// SmartFormat is not designed for processing JavaScript because of interfering usage of {}[].
+        /// This example shows that even a comment can lead to parsing will work or not.
+        /// </summary>
+        [TestCase("/* The comment with this '}{' makes it fail */", "############### {TheVariable} ###############", false)]
+        [TestCase("", "############### {TheVariable} ###############", true)]
+        public void Parse_JavaScript_May_Succeed_Or_Fail(string var0, string var1, bool shouldSucceed)
+        {
+            var js = @"
+(function(exports) {
+  'use strict';
+  /**
+   * Searches for specific element in a given array using
+   * the interpolation search algorithm.<br><br>
+   * Time complexity: O(log log N) when elements are uniformly
+   * distributed, and O(N) in the worst case
+   *
+   * @example
+   *
+   * var search = require('path-to-algorithms/src/searching/'+
+   * 'interpolation-search').interpolationSearch;
+   * console.log(search([1, 2, 3, 4, 5], 4)); // 3
+   *
+   * @public
+   * @module searching/interpolation-search
+   * @param {Array} sortedArray Input array.
+   * @param {Number} seekIndex of the element which index should be found.
+   * @returns {Number} Index of the element or -1 if not found.
+   */
+  function interpolationSearch(sortedArray, seekIndex) {
+    let leftIndex = 0;
+    let rightIndex = sortedArray.length - 1;
 
-            Assert.IsTrue(
-                result.StartsWith("The format string has")
-                );
+    while (leftIndex <= rightIndex) {
+      const rangeDiff = sortedArray[rightIndex] - sortedArray[leftIndex];
+      const indexDiff = rightIndex - leftIndex;
+      const valueDiff = seekIndex - sortedArray[leftIndex];
+
+      if (valueDiff < 0) {
+        return -1;
+      }
+
+      if (!rangeDiff) {
+        return sortedArray[leftIndex] === seekIndex ? leftIndex : -1;
+      }
+
+      const middleIndex =
+        leftIndex + Math.floor((valueDiff * indexDiff) / rangeDiff);
+
+      if (sortedArray[middleIndex] === seekIndex) {
+        return middleIndex;
+      }
+
+      if (sortedArray[middleIndex] < seekIndex) {
+        leftIndex = middleIndex + 1;
+      } else {
+        rightIndex = middleIndex - 1;
+      }
+    }
+    " + var0 + @"
+    /* " + var1 + @" */
+    return -1;
+  }
+  exports.interpolationSearch = interpolationSearch;
+})(typeof window === 'undefined' ? module.exports : window);
+";
+            var parser = GetRegularParser();
+            parser.Settings.ParseErrorAction = ErrorAction.MaintainTokens;
+            var parsed = parser.ParseFormat(js, new[] { Guid.NewGuid().ToString("N") });
+
+            // No characters should get lost compared to the format string,
+            // no matter if a Placeholder can be identified or not
+            Assert.That(parsed.Items.Sum(i => i.RawText.Length), Is.EqualTo(js.Length), "No characters lost");
+
+            if (shouldSucceed)
+            {
+                Assert.That(parsed.Items.Count(i => i.GetType() == typeof(Placeholder)), Is.EqualTo(1),
+                    "One placeholders");
+                Assert.That(parsed.Items.First(i => i.GetType() == typeof(Placeholder)).RawText,
+                    Is.EqualTo("{TheVariable}"));
+            }
+            else
+            {
+                Assert.That(parsed.Items.Count(i => i.GetType() == typeof(Placeholder)), Is.EqualTo(0),
+                    "NO placeholder");
+            }
+        }
+        
+        /// <summary>
+        /// SmartFormat is not designed for processing CSS because of interfering usage of {}[].
+        /// This example shows that even a comment can lead to parsing will work or not.
+        /// </summary>
+        [TestCase("", "############### {TheVariable} ###############", false)]
+        [TestCase("/* This '}' in the comment makes it succeed */", "############### {TheVariable} ###############", true)]
+        public void Parse_Css_May_Succeed_Or_Fail(string var0, string var1, bool shouldSucceed)
+        {
+            var css = @"
+.media {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+}
+
+.media .content {
+  font-size: .8rem;
+}
+
+.comment img {
+  border: 1px solid grey;  " + var0 + @"
+  anything: '" + var1 + @"'
+}
+
+.list-item {
+  border-bottom: 1px solid grey;
+} 
+";
+            var parser = GetRegularParser();
+            parser.Settings.ParseErrorAction = ErrorAction.MaintainTokens;
+            var parsed = parser.ParseFormat(css, new[] { Guid.NewGuid().ToString("N") });
+
+            // No characters should get lost compared to the format string,
+            // no matter if a Placeholder can be identified or not
+            Assert.That(parsed.Items.Sum(i => i.RawText.Length), Is.EqualTo(css.Length), "No characters lost");
+
+            if (shouldSucceed)
+            {
+                Assert.That(parsed.Items.Count(i => i.GetType() == typeof(Placeholder)), Is.EqualTo(1),
+                    "One placeholders");
+                Assert.That(parsed.Items.First(i => i.GetType() == typeof(Placeholder)).RawText,
+                    Is.EqualTo("{TheVariable}"));
+            }
+            else
+            {
+                Assert.That(parsed.Items.Count(i => i.GetType() == typeof(Placeholder)), Is.EqualTo(0),
+                    "NO placeholder");
+            }
         }
 
         [Test]

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -8,7 +8,7 @@
 		<Version>2.6.2.0</Version>
         <FileVersion>2.6.2.0</FileVersion>
 		<AssemblyVersion>2.6.2.0</AssemblyVersion>
-        <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>net462;net5.0</TargetFrameworks>
 		<DefineConstants>$(DefineConstants)</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<AssemblyName>SmartFormat.Tests</AssemblyName>
@@ -37,7 +37,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\SmartFormat\SmartFormat.csproj" />
+	  <ProjectReference Include="..\SmartFormat\SmartFormat.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/SmartFormat/Core/Parsing/LiteralText.cs
+++ b/src/SmartFormat/Core/Parsing/LiteralText.cs
@@ -33,6 +33,7 @@ namespace SmartFormat.Core.Parsing
         private string ConvertCharacterLiteralsToUnicode()
         {
             var source = baseString.Substring(startIndex, endIndex - startIndex);
+            if (source.Length == 0) return source;
 
             // No character literal escaping - nothing to do
             if (source[0] != Parser.CharLiteralEscapeChar)

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -445,21 +445,26 @@ namespace SmartFormat.Core.Parsing
                 }
             }
 
-            // finish the last text item:
-            if (lastI != format.Length)
-                current.Items.Add(new LiteralText(Settings, current, lastI) {endIndex = format.Length});
-
-            // Check that the format is finished:
+            // We're at the end of the input string
+            
+            // 1. Is the last item a placeholder, that is not finished yet?
             if (current.parent != null || currentPlaceholder != null)
             {
                 parsingErrors.AddIssue(current, parsingErrorText[ParsingError.MissingClosingBrace], format.Length,
                     format.Length);
                 current.endIndex = format.Length;
-                while (current.parent != null)
-                {
-                    current = current.parent.parent;
-                    current.endIndex = format.Length;
-                }
+            }
+            else if (lastI != format.Length)
+            {
+                // 2. The last item must be a literal, so add it
+                current.Items.Add(new LiteralText(Settings, current, lastI) {endIndex = format.Length});
+            }
+            
+            // Todo v2.7.0: There is no unit test for this condition!
+            while (current.parent != null)
+            {
+                current = current.parent.parent;
+                current.endIndex = format.Length;
             }
 
             // Check for any parsing errors:

--- a/src/SmartFormat/Core/Parsing/ParsingErrors.cs
+++ b/src/SmartFormat/Core/Parsing/ParsingErrors.cs
@@ -26,17 +26,8 @@ namespace SmartFormat.Core.Parsing
         public List<ParsingIssue> Issues { get; }
         public bool HasIssues => Issues.Count > 0;
 
-        public string MessageShort
-        {
-            get
-            {
-                return string.Format("The format string has {0} issue{1}: {2}",
-                    Issues.Count,
-                    Issues.Count == 1 ? "" : "s",
-                    string.Join(", ", Issues.Select(i => i.Issue).ToArray())
-                );
-            }
-        }
+        public string MessageShort =>
+            $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? "" : "s")}: {string.Join(", ", Issues.Select(i => i.Issue).ToArray())}";
 
         public override string Message
         {
@@ -59,13 +50,8 @@ namespace SmartFormat.Core.Parsing
                     }
                 }
 
-                return string.Format("The format string has {0} issue{1}:\n{2}\nIn: \"{3}\"\nAt:  {4} ",
-                    Issues.Count,
-                    Issues.Count == 1 ? "" : "s",
-                    string.Join(", ", Issues.Select(i => i.Issue).ToArray()),
-                    result.baseString,
-                    arrows
-                );
+                return
+                    $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? "" : "s")}:\n{string.Join(", ", Issues.Select(i => i.Issue).ToArray())}\nIn: \"{result.baseString}\"\nAt:  {arrows} ";
             }
         }
 

--- a/src/SmartFormat/SmartFormat.csproj
+++ b/src/SmartFormat/SmartFormat.csproj
@@ -7,7 +7,7 @@
         <AssemblyVersion>2.6.2.0</AssemblyVersion>
         <FileVersion>2.6.2.0</FileVersion>
         <Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net462;net472;net48;net50</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG</DefineConstants>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AssemblyName>SmartFormat</AssemblyName>


### PR DESCRIPTION
This PR addresses issues referenced in #148, #147, #143.

**Also fixed:**
If the last item of a format string was an uncompleted `Placeholder` (e.g. ending `"like {uncomplete"`), the parser now takes it as an erroneous `Placeholder`, not as a `TextLiteral` (as it was the case until v2.6.2).

---

@andersjonsson @nikita-starostin @hugoqribeiro: Your feedback on this PR would be appreciated.

> Here is the draft package of `SmartFormat.NET.2.7.0-preview-1` (not published yet, more to come):
[SmartFormat.NET.2.7.0-preview-1.zip](https://github.com/axuno/SmartFormat/files/6250870/SmartFormat.NET.2.7.0-preview-1.zip)

@andersjonsson @nikita-starostin Since v2.6.2 the following issue is breaking backward-compatibility:

**`Parser.ErrorAction.MaintainTokens`**: If one of serveral `Placeholder`s has `ParsingErrors`, all `Placeholder`s are just displayed with their tokens. *Expected*: Only `Placeholder`s with `ParsingErrors` should show up with their tokens, others should be formatted.

This has been fixed,

Other issues with the `Parser` have been fixed, too:

1. `Parser.ErrorAction.Ignore`: Only `Placeholder`s with `ParsingErrors` become `string.Empty`, others are formatted.
2.  Since v1.6.1 there is an undiscovered issue: If `Parser` found a `ParsingError.TooManyClosingBraces`, this closing brace was simply "swallowed-up". *Expected:* The redundant closing brace should be treated as a literal. Otherwise the result with `Parser.ErrorAction.MaintainTokens` has differences to the original format string.

**@hugoqribeiro @nikita-starostin**: You are using *SmartFormat.NET* for processing HTML strings with JavaScript or CSS.
1. With the fixes described above, chances for *SmartFormat.NET* to succeed, will increase.
2. The following tests will make clear, why this is not reliable, and this unfortunately cannot be improved further:
  * https://github.com/axuno/SmartFormat/blob/ced05bb4ada38e8a34554318616cd3b278c57da9/src/SmartFormat.Tests/Core/ParserTests.cs#L172
  * https://github.com/axuno/SmartFormat/blob/ced05bb4ada38e8a34554318616cd3b278c57da9/src/SmartFormat.Tests/Core/ParserTests.cs#L260

