### PR TITLE
Introduced Nullable Notation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,48 @@ v3.0.0 (Draft)
 
 ### Currently merged to the `version/v3.0` branch:
 
+#### Introduced Nullable Notation
+
+The C# like `nullable` notation allows to display `Nullable<T>` types, depending on whether a variable contains the underlying type's value or `null`. The SmartFormat notation is `"{SomeNullable?.Property}"`. If `SomeNullable` is null, the expression is evaluated as `string.empty`.
+
+In this context the `NullFormatter` was introduced. It outputs a custom string literal, if the variable is `null`, else `string.empty`.
+
+Putting both together:
+
+```Csharp
+var smart = new SmartFormatter();
+smart.AddExtensions(new IFormatter[] { new NullFormatter() });
+```
+The variable is `null`:
+```Csharp
+// nullResult: "This value is null"
+var nullResult = smart.Format("{TheValue:isnull:This value is null}", new {TheValue = null});
+// valueResult: string.Empty
+var valueResult = smart.Format("{TheValue?}", new {TheValue = null});
+```
+The variable is a `string` value:
+```Csharp
+// nullResult: string.Empty
+nullResult = smart.Format("{TheValue:isnull:This value is null}", new {TheValue = "My string value"});
+// valueResult: "My string value"
+valueResult = smart.Format("{TheValue?}", new {TheValue = "My string value"});
+```
+In the most simple scenario, both evaluations can be combined with the `ChooseFormatter`:
+```Csharp
+// result: "This value is null" or the string value
+var result = smart.Format("{TheValue?choose(null):This value is null|{}}}", new {TheValue = null});
+```
+In more complex scenarios, you will, however, use the nullable notation together with other extensions, like a `ListFormatter`.
+
+**Note:** Trying to evaluate `null` without the nullable operator will result in a formatting exception. This is the same behavior as in SmartFormat 2.x.
+
+Changes connected to nullable notation:
+* Source extension should have `Source` as the abstract base class, instead of `ISource`.
+* Source extensions should check for `null` values with the nullable operator and return `true` in the `bool TryEvaluateSelector(ISelectorInfo selectorInfo)` method.
+* The `Parser` accepts `?` as another standard operator.
+* The `NullFormatter` is invoked implicitly before any other `IFormatter`. `null` will be output as `string.Empty`. This behavior can be overridden in a derived class.
+* The nullable operator can also be used evaluating a list index, e.g. `"{TheList?[1]}"`.
+
 #### Refactored implementation for string alignment ([#174](https://github.com/axuno/SmartFormat/pull/174))
 Example: `Smart.Format("{placeholder,15}")` where ",15" is the string alignment
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ Example: `Smart.Format("{placeholder,15}")` where ",15" is the string alignment
    
    * The `Parser` will not include the formatter name or formatting options. Like with `string.Format`, everything after the `Selector` separator (colon) is considered as format specifier.
    * Curly braces are escaped the `string.Format` way with `{{` and `}}`
-   * `DefaultFormatter` is the only formatter which will be invoked.
+   * `DefaultFormatter` is the only formatter which will be invoked. `null` will be output as `string.Empty`.
    * Even in compatibility mode, *SmartFormat* will
      * Process named `Placeholder`s (beside indexed `Placeholder`s)
      * have `ISource`s available for `Placeholder`s.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,10 +32,10 @@ nullResult = smart.Format("{TheValue:isnull:This value is null}", new {TheValue 
 // valueResult: "My string value"
 valueResult = smart.Format("{TheValue?}", new {TheValue = "My string value"});
 ```
-In the most simple scenario, both evaluations can be combined with the `ChooseFormatter`:
+In the most simple scenario, both evaluations can also be combined with the `ChooseFormatter`:
 ```Csharp
 // result: "This value is null" or the string value
-var result = smart.Format("{TheValue?choose(null):This value is null|{}}}", new {TheValue = null});
+var result = smart.Format("{TheValue?:choose(null):This value is null|{}}}", new {TheValue = null});
 ```
 In more complex scenarios, you will, however, use the nullable notation together with other formatter extensions, like a `ListFormatter`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,15 +37,14 @@ In the most simple scenario, both evaluations can be combined with the `ChooseFo
 // result: "This value is null" or the string value
 var result = smart.Format("{TheValue?choose(null):This value is null|{}}}", new {TheValue = null});
 ```
-In more complex scenarios, you will, however, use the nullable notation together with other extensions, like a `ListFormatter`.
+In more complex scenarios, you will, however, use the nullable notation together with other formatter extensions, like a `ListFormatter`.
 
 **Note:** Trying to evaluate `null` without the nullable operator will result in a formatting exception. This is the same behavior as in SmartFormat 2.x.
 
 Changes connected to nullable notation:
 * Source extension should have `Source` as the abstract base class, instead of `ISource`.
-* Source extensions should check for `null` values with the nullable operator and return `true` in the `bool TryEvaluateSelector(ISelectorInfo selectorInfo)` method.
+* Source extensions should check for `null` values together with the nullable operator and return `true` in the `bool TryEvaluateSelector(ISelectorInfo selectorInfo)` method.
 * The `Parser` accepts `?` as another standard operator.
-* The `NullFormatter` is invoked implicitly before any other `IFormatter`. `null` will be output as `string.Empty`. This behavior can be overridden in a derived class.
 * The nullable operator can also be used evaluating a list index, e.g. `"{TheList?[1]}"`.
 
 #### Refactored implementation for string alignment ([#174](https://github.com/axuno/SmartFormat/pull/174))

--- a/src/SmartFormat.Tests/Core/FormatCacheTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatCacheTests.cs
@@ -16,7 +16,6 @@ namespace SmartFormat.Tests.Core
             formatter.FormatterExtensions.Add(new DefaultFormatter());
             formatter.SourceExtensions.Add(new ReflectionSource(formatter));
             formatter.SourceExtensions.Add(new DefaultSource(formatter));
-            formatter.Parser.AddAlphanumericSelectors();
             return formatter;
         }
 

--- a/src/SmartFormat.Tests/Core/FormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatterTests.cs
@@ -171,10 +171,8 @@ namespace SmartFormat.Tests.Core
             var output = new StringOutput();
             var formatter = new SmartFormatter();
             formatter.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
-            formatter.Settings.ConvertCharacterStringLiterals = true;
             formatter.Settings.Formatter.ErrorAction = FormatErrorAction.OutputErrorInResult;
             formatter.Settings.Parser.ErrorAction = ParseErrorAction.OutputErrorInResult;
-            formatter.Parser.AddAlphanumericSelectors(); // required for this test
             var formatParsed = formatter.Parser.ParseFormat(format);
             var formatDetails = new FormatDetails(formatter, formatParsed, args, null, null, output);
             

--- a/src/SmartFormat.Tests/Core/FormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatterTests.cs
@@ -206,5 +206,12 @@ namespace SmartFormat.Tests.Core
             var formatter = GetSimpleFormatter();
             Assert.That(formatter.GetSourceExtension<DefaultSource>(), Is.InstanceOf(typeof(DefaultSource)));  ;
         }
+
+        [Test]
+        public void Not_Existing_Formatter_Name_Should_Throw()
+        {
+            var smart = GetSimpleFormatter();
+            Assert.That(() => smart.Format("{0:not_existing_formatter_name:}", new object()), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("not_existing_formatter_name"));
+        }
     }
 }

--- a/src/SmartFormat.Tests/Core/NestingTests.cs
+++ b/src/SmartFormat.Tests/Core/NestingTests.cs
@@ -68,7 +68,6 @@ namespace SmartFormat.Tests.Core
         {
             // Removing the spaces from Nesting_can_access_outer_scopes requires alternative escaping of { and }!
             var sf = Smart.CreateDefaultSmartFormat();
-            sf.Parser.UseAlternativeEscapeChar('\\');
             var actual = sf.Format(format, data);
             Assert.AreEqual(expectedOutput, actual);
         }

--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -650,7 +650,7 @@ namespace SmartFormat.Tests.Core
 
             var placeholder = result.Items[0] as Placeholder;
             Assert.That(placeholder, Is.Not.Null);
-            Assert.That(placeholder.Selectors.Count, Is.EqualTo(1));
+            Assert.That(placeholder!.Selectors.Count, Is.EqualTo(1));
             Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(formatString.Substring(1,2)));
         }
 
@@ -664,7 +664,7 @@ namespace SmartFormat.Tests.Core
 
             var placeholder = result.Items[0] as Placeholder;
             Assert.That(placeholder, Is.Not.Null);
-            Assert.That(placeholder.Selectors.Count, Is.EqualTo(2));
+            Assert.That(placeholder!.Selectors.Count, Is.EqualTo(2));
             Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(formatString.Substring(1,1)));
             Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(formatString.Substring(3, 1)));
             Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(formatString.Substring(2,1)));
@@ -690,7 +690,7 @@ namespace SmartFormat.Tests.Core
 
             var placeholder = result.Items[0] as Placeholder;
             Assert.That(placeholder, Is.Not.Null);
-            Assert.That(placeholder.Selectors.Count, Is.EqualTo(numOfSelectors));
+            Assert.That(placeholder!.Selectors.Count, Is.EqualTo(numOfSelectors));
             if (numOfSelectors == 2)
             {
                 Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_0"].Value));
@@ -723,7 +723,7 @@ namespace SmartFormat.Tests.Core
 
             var placeholder = result.Items[0] as Placeholder;
             Assert.That(placeholder, Is.Not.Null);
-            Assert.That(placeholder.Selectors.Count, Is.EqualTo(2));
+            Assert.That(placeholder!.Selectors.Count, Is.EqualTo(2));
             Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(formatString.Substring(1,1)));
             Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(formatString.Substring(4,1)));
             Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(formatString.Substring(2,2)));

--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -5,6 +5,7 @@ using SmartFormat.Tests.Common;
 using SmartFormat.Tests.TestUtils;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SmartFormat.Tests.Core
 {
@@ -640,7 +641,7 @@ namespace SmartFormat.Tests.Core
 
         [TestCase("{A }", ' ')]
         [TestCase("{B§}", '§')]
-        [TestCase("{?C}", '?')]
+        [TestCase("{%C}", '%')]
         public void Selector_With_Custom_Selector_Character(string formatString, char customChar)
         {
             var parser = GetRegularParser();
@@ -669,14 +670,54 @@ namespace SmartFormat.Tests.Core
             Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(formatString.Substring(2,1)));
         }
 
-        [TestCase("{C?.D}", '?')] 
-        [TestCase("{C..D}", '.')] 
-        public void Selector_With_Contiguous_Operator_Characters(string formatString, char customChar)
+        [TestCase("{A?.B}")]
+        [TestCase("{Selector0?.Selector1}")]
+        [TestCase("{A?[1].B}")]
+        [TestCase("{List?[123].Selector}")]
+        public void Selector_With_Nullable_Operator_Character(string formatString)
         {
-            // contiguous operators '?.' are parsed as ONE
+            // contiguous operator characters are parsed as "ONE operator string"
+
+            var regex = new Regex(@"\{(?<Sel_0>[a-zA-Z0-9]+)(?<Sel_1_Op>[\?\.|\[]+)(?<Sel_1>\d*)(?<Sel_2_Op>[\?|\.|\]]+)(?<Sel_2>[a-zA-Z0-9]+)\}",
+                RegexOptions.None);
+            var reMatches = regex.Matches(formatString);
+            var numOfSelectors = (reMatches[0].Groups["Sel_0"].Value == string.Empty ? 0 : 1) +
+                (reMatches[0].Groups["Sel_1"].Value == string.Empty ? 0 : 1) +
+                (reMatches[0].Groups["Sel_2"].Value == string.Empty ? 0 : 1);
 
             var parser = GetRegularParser();
-            // adding '.' is ignored, as it's the standard operator
+            var result = parser.ParseFormat(formatString);
+
+            var placeholder = result.Items[0] as Placeholder;
+            Assert.That(placeholder, Is.Not.Null);
+            Assert.That(placeholder.Selectors.Count, Is.EqualTo(numOfSelectors));
+            if (numOfSelectors == 2)
+            {
+                Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_0"].Value));
+                // Group Sel_1 is empty
+                Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_2"].Value));
+                // Concatenate because of regex simplification for 2 selectors
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value + reMatches[0].Groups["Sel_2_Op"].Value));
+            }
+            else
+            {
+                Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_0"].Value));
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
+                Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_1"].Value));
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
+                Assert.That(placeholder.Selectors[2].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_2"].Value));
+            }
+        }
+
+        [TestCase("{A?.B}", '.')] // with "nullable" operator
+        [TestCase("{C%.D}", '%')] 
+        [TestCase("{C..D}", '.')] 
+        public void Selector_With_Other_Contiguous_Operator_Characters(string formatString, char customChar)
+        {
+            // contiguous operator characters are parsed as "ONE operator string"
+
+            var parser = GetRegularParser();
+            // adding '.' is ignored, as it's a standard operator
             parser.Settings.Parser.AddCustomOperatorChars(new[]{customChar});
             var result = parser.ParseFormat(formatString);
 

--- a/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
@@ -67,11 +67,11 @@ namespace SmartFormat.Tests.Extensions
             Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
         }
         
-        [TestCase("{0:choose(null):nothing|{} }", null, "nothing")]
-        [TestCase("{0:choose(null):nothing|{} }", 5, "5 ")]
-        [TestCase("{0:choose(null|5):nothing|five|{} }", null, "nothing")]
-        [TestCase("{0:choose(null|5):nothing|five|{} }", 5, "five")]
-        [TestCase("{0:choose(null|5):nothing|five|{} }", 6, "6 ")]
+        [TestCase("{0:choose(null):nothing|{}}", null, "nothing")]
+        [TestCase("{0:choose(null):nothing|{}}", 5, "5")]
+        [TestCase("{0:choose(null|5):nothing|five|{}}", null, "nothing")]
+        [TestCase("{0:choose(null|5):nothing|five|{}}", 5, "five")]
+        [TestCase("{0:choose(null|5):nothing|five|{}}", 6, "6")]
         public void Choose_has_a_special_case_for_null(string format, object arg0, string expectedResult)
         {
             Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));

--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -8,31 +8,13 @@ namespace SmartFormat.Tests.Extensions
     [TestFixture]
     public class ConditionalFormatterTests
     {
-        private object[] GetArgs()
-        {
-            return new object[] {
-                0,1,2,3,
-                -1,-2, // {4},{5}
-                TestFactory.GetPerson(), // {6}
-                false,true, // {7},{8}
-                // Note: only the date part will be compared:
-                new DateTime(1111,1,1,1,1,1),SystemTime.Now(),new DateTime(5555,5,5,5,5,5), // {9},{10},{11}
-                new TimeSpan(-1,-1,-1,-1,-1), TimeSpan.Zero,new TimeSpan(5,5,5,5,5), // {12},{13},{14}
-                "Hello", "", // {15},{16}
-                new {NotNull = true}, null!, // {17},{18}
-                // Note: only the date part will be compared:
-                SystemTime.OffsetNow().AddDays(-1),SystemTime.OffsetNow(),SystemTime.OffsetNow().AddDays(1) // {19},{20},{21}
-            };
-        }
-
         [Test]
         public void Test_Numbers()
         {
-            // Note: the "::" is necessary to bypass the PluralLocalizationExtension, and will be ignored in the output
             var formats = new[] {
-                "{0::Zero|Other} {1::Zero|Other} {2::Zero|Other} {3::Zero|Other} {4::Zero|Other} {5::Zero|Other}",
-                "{0::Zero|One|Other} {1::Zero|One|Other} {2::Zero|One|Other} {3::Zero|One|Other} {4::Zero|One|Other} {5::Zero|One|Other}",
-                "{0::Zero|One|Two|Other} {1::Zero|One|Two|Other} {2::Zero|One|Two|Other} {3::Zero|One|Two|Other} {4::Zero|One|Two|Other} {5::Zero|One|Two|Other}",
+                "{0:cond:Zero|Other} {1:cond:Zero|Other} {2:cond:Zero|Other} {3:cond:Zero|Other} {4:cond:Zero|Other} {5:cond:Zero|Other}",
+                "{0:cond:Zero|One|Other} {1:cond:Zero|One|Other} {2:cond:Zero|One|Other} {3:cond:Zero|One|Other} {4:cond:Zero|One|Other} {5:cond:Zero|One|Other}",
+                "{0:cond:Zero|One|Two|Other} {1:cond:Zero|One|Two|Other} {2:cond:Zero|One|Two|Other} {3:cond:Zero|One|Two|Other} {4:cond:Zero|One|Two|Other} {5:cond:Zero|One|Two|Other}",
             };
             var expected = new[] {
                 "Zero Other Other Other Other Other",
@@ -40,16 +22,16 @@ namespace SmartFormat.Tests.Extensions
                 "Zero One Two Other Other Other",
             };
 
-            var args = GetArgs();
+            var args = new object[] {0, 1, 2, 3, -1, -2};
             Smart.Default.Test(formats, args, expected);
         }
         [Test]
         public void Test_Enum()
         {
             var formats = new[] {
-                "{6.Friends.0:{FirstName} is a {Gender:man|woman}.}",
-                "{6.Friends.1:{FirstName} is a {Gender:man|woman}.}",
-                "{9.DayOfWeek:Sunday|Monday|Some other day} / {11.DayOfWeek:Sunday|Monday|Some other day}",
+                "{0.Friends.0:{FirstName} is a {Gender:man|woman}.}",
+                "{0.Friends.1:{FirstName} is a {Gender:man|woman}.}",
+                "{2.DayOfWeek:Sunday|Monday|Some other day} / {3.DayOfWeek:Sunday|Monday|Some other day}",
             };
             var expected = new[] {
                 "Jim is a man.",
@@ -57,52 +39,57 @@ namespace SmartFormat.Tests.Extensions
                 "Sunday / Some other day",
             };
 
-            var args = GetArgs();
+            var args = new object[] {TestFactory.GetPerson(), TestFactory.GetPerson(), new DateTime(1111,1,1,1,1,1), new DateTime(5555,5,5,5,5,5)};
             Smart.Default.Test(formats, args, expected);
         }
+
         [Test]
         public void Test_Bool()
         {
             var formats = new[] {
-                "{7:Yes|No}",
-                "{8:Yes|No}",
+                "{0:Yes|No}",
+                "{1:Yes|No}",
             };
             var expected = new[] {
                 "No",
                 "Yes",
             };
 
-            var args = GetArgs();
+            var args = new object[]{false, true};
             Smart.Default.Test(formats, args, expected);
         }
+
         [Test]
         public void Test_Dates()
         {
             var formats = new[] {
-                "{9:Past|Future} {10:Past|Future} {11:Past|Future}",
-                "{9:Past|Present|Future} {10:Past|Present|Future} {11:Past|Present|Future}",
+                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
+                "{0:Past|Present|Future} {1:Past|Present|Future} {2:Past|Present|Future}",
             };
             var expected = new[] {
                 "Past Past Future",
                 "Past Present Future",
             };
 
-            var args = GetArgs();
+            // only the date part will be compared
+            var args = new object[] {new DateTime(1111,1,1,1,1,1),SystemTime.Now(),new DateTime(5555,5,5,5,5,5)};
             Smart.Default.Test(formats, args, expected);
         }
         [Test]
         public void Test_DateTimeOffset_Dates()
         {
             var formats = new[] {
-                "{19:Past|Future} {20:Past|Future} {21:Past|Future}",
-                "{19:Past|Present|Future} {20:Past|Present|Future} {21:Past|Present|Future}",
+                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
+                "{0:Past|Present|Future} {1:Past|Present|Future} {2:Past|Present|Future}",
             };
             var expected = new[] {
                 "Past Past Future",
                 "Past Present Future",
             };
 
-            var args = GetArgs();
+            // only the date part will be compared
+            var args = new object[]
+                {SystemTime.OffsetNow().AddDays(-1), SystemTime.OffsetNow(), SystemTime.OffsetNow().AddDays(1)};
             Smart.Default.Test(formats, args, expected);
         }
 
@@ -110,42 +97,33 @@ namespace SmartFormat.Tests.Extensions
         public void Test_TimeSpan()
         {
             var formats = new[] {
-                "{12:Past|Future} {13:Past|Future} {14:Past|Future}",
-                "{12:Past|Zero|Future} {13:Past|Zero|Future} {14:Past|Zero|Future}",
+                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
+                "{0:Past|Zero|Future} {1:Past|Zero|Future} {2:Past|Zero|Future}",
             };
             var expected = new[] {
                 "Past Past Future",
                 "Past Zero Future",
             };
 
-            var args = GetArgs();
+            var args = new object[] {new TimeSpan(-1,-1,-1,-1,-1), TimeSpan.Zero,new TimeSpan(5,5,5,5,5)};
             Smart.Default.Test(formats, args, expected);
         }
-        [Test]
-        public void Test_Strings()
-        {
-            var formats = new[] {
-                "{15:{}|Empty} {16:{}|Empty} {18:{}|Null}",
-            };
-            var expected = new[] {
-                "Hello Empty Null",
-            };
 
-            var args = GetArgs();
-            Smart.Default.Test(formats, args, expected);
+        [TestCase("{0:cond:{}|Empty}", "Hello")]
+        [TestCase("{1:cond:{}|Empty}", "Empty")]
+        [TestCase("{2:cond:{}|Null}", "Null")]
+        public void Test_Strings(string format, string expected)
+        {
+            var args = new object[] { "Hello", "", null! };
+            Smart.Default.Test(format, args, expected);
         }
-        [Test]
-        public void Test_Object()
-        {
-            var formats = new[] {
-                "{17:{}|Null}; {18:{}|Null}",
-            };
-            var expected = new[] {
-                "{ NotNull = True }; Null",
-            };
 
-            var args = GetArgs();
-            Smart.Default.Test(formats, args, expected);
+        [TestCase("{0:cond:{}|Null}", "{ NotNull = True }")] // 'expected' comes from the default formatter, writing the anonymous type with 'ToString()'
+        [TestCase("{1:cond:{}|Null}", "Null")]
+        public void Test_Object(string format, string expected)
+        {
+            var args = new object[] {new {NotNull = true}, null!};
+            Smart.Default.Test(format, args, expected);
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
@@ -123,7 +123,7 @@ namespace SmartFormat.Tests.Extensions
             const string format = "Address: {City.ZipCode} {City.Name}, {City.AreaCode}\n" +
                                   "Name: {Person.FirstName} {Person.LastName}";
 
-            var expected = $"Address: {addr.City.ZipCode} {addr.City.Name}, {addr.City.AreaCode}\n" +
+            var expected = $"Address: {addr.City?.ZipCode} {addr.City?.Name}, {addr.City?.AreaCode}\n" +
                          $"Name: {addr.Person.FirstName} {addr.Person.LastName}";
 
             var formatter = Smart.CreateDefaultSmartFormat();

--- a/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic;
 using Newtonsoft.Json.Linq;
-#if NET45
-using System.Runtime.Remoting.Messaging;
-#endif
 using NUnit.Framework;
+using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
 using SmartFormat.Tests.TestUtils;
@@ -37,7 +34,7 @@ namespace SmartFormat.Tests.Extensions
             };
 
             return new object[] {
-                d,
+                d
             };
         }
 
@@ -59,20 +56,19 @@ namespace SmartFormat.Tests.Extensions
         {
             var formatter = Smart.CreateDefaultSmartFormat();
             formatter.AddExtensions(new DictionarySource(formatter));
-            formatter.Parser.UseAlternativeEscapeChar(); // curly braces MUST be escaped with \{ and \} instead of {{ and }} for this complex test
 
-            var formats = new string[] {
+            var formats = new[]
+            {
                 "Chained: {0.Numbers.One} {Numbers.Two} {Letters.A} {Object.Prop1}",
-                "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}}" 
+                "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}}"
             };
-            var expected = new string[] {
+            var expected = new[]
+            {
                 "Chained: 1 2 a a",
                 "Nested: 1 2 a a"
             };
             var args = GetArgs();
             formatter.Test(formats, args, expected);
-
-            formatter.Parser.UseBraceEscaping(); // reset to string.Format brace escaping
         }
 
         [Test]
@@ -80,20 +76,19 @@ namespace SmartFormat.Tests.Extensions
         {
             var formatter = Smart.CreateDefaultSmartFormat();
             formatter.AddExtensions(new DictionarySource(formatter));
-            formatter.Parser.UseAlternativeEscapeChar(); // curly braces MUST be escaped with \{ and \} instead of {{ and }} for this complex test
 
-            var formats = new string[] {
+            var formats = new[]
+            {
                 "Chained: {0.Numbers.One} {Numbers.Two} {Letters.A} {Object.Prop1} {Raw.X}",
                 "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}} {Raw:{X}}"
             };
-            var expected = new string[] {
+            var expected = new[]
+            {
                 "Chained: 1 2 a a z",
                 "Nested: 1 2 a a z"
             };
             var args = (object[])GetDynamicArgs();
             formatter.Test(formats, args, expected);
-
-            formatter.Parser.UseBraceEscaping(); // reset to string.Format brace escaping
         }
 
         [Test]
@@ -102,20 +97,19 @@ namespace SmartFormat.Tests.Extensions
             var formatter = Smart.CreateDefaultSmartFormat();
             formatter.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
             formatter.AddExtensions(new DictionarySource(formatter));
-            formatter.Parser.UseAlternativeEscapeChar(); // curly braces MUST be escaped with \{ and \} instead of {{ and }} for this complex test
 
-            var formats = new string[] {
+            var formats = new string[]
+            {
                 "Chained: {0.Numbers.One} {Numbers.Two} {Letters.A} {Object.Prop1} {Raw.x}",
                 "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}} {Raw:{x}}"
             };
-            var expected = new string[] {
+            var expected = new string[]
+            {
                 "Chained: 1 2 a a z",
                 "Nested: 1 2 a a z"
             };
             var args = (object[])GetDynamicArgs();
             formatter.Test(formats, args, expected);
-
-            formatter.Parser.UseBraceEscaping(); // reset to string.Format brace escaping
         }
 
         [Test]
@@ -138,25 +132,44 @@ namespace SmartFormat.Tests.Extensions
             Assert.AreEqual(expected, result);
         }
 
+        [Test]
+        public void Dictionary_Dot_Notation_Nullable()
+        {
+            // Process properties of a class instance type-safe and without the need for reflection
+            // and with nullable dot notation for dictionaries
+
+            var addr = new Address {City = null};
+
+            var addrDict = addr.ToDictionary();
+
+            const string format = "Address: {City?.ZipCode} {City?.Name} {City?.AreaCode}\n" +
+                                  "Name: {Person.FirstName} {Person.LastName}";
+
+            var expected = $"Address: {addr.City?.ZipCode} {addr.City?.Name} {addr.City?.AreaCode}\n" +
+                           $"Name: {addr.Person.FirstName} {addr.Person.LastName}";
+
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new ISource[] { new DefaultSource(smart), new DictionarySource(smart) });
+            smart.AddExtensions(new IFormatter[] {new DefaultFormatter()});
+            
+            var result = smart.Format(format, addrDict);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
 
         public class Address
         {
-            public CityDetails City { get; set; } = new CityDetails();
-            public PersonDetails Person { get; set; } = new PersonDetails();
+            public CityDetails? City { get; set; } = new();
+            public PersonDetails Person { get; set; } = new();
 
-            public Dictionary<string, object> ToDictionary()
+            public Dictionary<string, object?> ToDictionary()
             {
-                var d = new Dictionary<string, object>
+                var d = new Dictionary<string, object?>
                 {
-                    { nameof(City), City.ToDictionary() },
+                    { nameof(City), City?.ToDictionary() },
                     { nameof(Person), Person.ToDictionary() }
                 };
                 return d;
-            }
-
-            public JObject ToJson()
-            {
-                return JObject.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(this));
             }
 
             public class CityDetails
@@ -165,9 +178,9 @@ namespace SmartFormat.Tests.Extensions
                 public string ZipCode { get; set; } = "00501";
                 public string AreaCode { get; set; } = "631";
 
-                public Dictionary<string, string> ToDictionary()
+                public Dictionary<string, string?> ToDictionary()
                 {
-                    return new Dictionary<string, string>
+                    return new()
                     {
                         {nameof(Name), Name},
                         {nameof(ZipCode), ZipCode},
@@ -182,10 +195,10 @@ namespace SmartFormat.Tests.Extensions
                 public string LastName { get; set; } = "Doe";
                 public Dictionary<string, string> ToDictionary()
                 {
-                    return new Dictionary<string, string>
+                    return new()
                     {
                         {nameof(FirstName), FirstName},
-                        {nameof(LastName), LastName}
+                        {nameof(LastName), LastName},
                     };
                 }
             }

--- a/src/SmartFormat.Tests/Extensions/JsonSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/JsonSourceTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using Newtonsoft.Json.Linq;
 using System.Text.Json;
 using NUnit.Framework;
+using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
@@ -12,13 +13,6 @@ namespace SmartFormat.Tests.Extensions
     [TestFixture]
     public class JsonSourceTests
     {
-        private SmartFormatter _formatter = Smart.CreateDefaultSmartFormat();
-
-        public JsonSourceTests()
-        {
-            _formatter.SourceExtensions.Add(new JsonSource(Smart.Default));
-        }
-
         private const string JsonOneLevel = @"{'Name': 'Doe'}";
         private const string JsonTwoLevel = @"{'Name': {'First': 'Joe'}}";
         private const string JsonNull = @"{'Name': null}";
@@ -56,13 +50,22 @@ namespace SmartFormat.Tests.Extensions
   ]
 }";
 
+        private SmartFormatter GetJsonFormatter()
+        {
+            var smart = new SmartFormatter();
+            // JsonSource MUST be registered before ReflectionSource (which is not required here)
+            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new JsonSource(smart) });
+            smart.AddExtensions(new IFormatter[] {new ListFormatter(smart), new DefaultFormatter()});
+            return smart;
+        }
+
         #region *** NewtonSoftJson ***
 
         [Test]
         public void NS_Format_Null_Json()
         {
             var jObject = JObject.Parse(JsonNull);
-            var result = _formatter.Format("{Name}", jObject);
+            var result = GetJsonFormatter().Format("{Name}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -70,7 +73,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_OneLevel_Json()
         {
             var jObject = JObject.Parse(JsonOneLevel);
-            var result = _formatter.Format("{Name}", jObject);
+            var result = GetJsonFormatter().Format("{Name}", jObject);
             Assert.AreEqual("Doe", result);
         }
 
@@ -78,53 +81,57 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_TwoLevel_Json()
         {
             var jObject = JObject.Parse(JsonTwoLevel);
-            var result = _formatter.Format("{Name.First}", jObject);
+            var result = GetJsonFormatter().Format("{Name.First}", jObject);
             Assert.AreEqual("Joe", result);
+        }
+
+        [Test]
+        public void NS_Format_TwoLevel_Nullable_Json()
+        {
+            var jObject = JObject.Parse(JsonNull);
+            var result = GetJsonFormatter().Format("{Name?.First}", jObject);
+            Assert.AreEqual("", result);
         }
 
         [Test]
         public void NS_Format_Complex_Json()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var savedSetting = Smart.Default.Settings.CaseSensitivity;
-            Smart.Default.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
+            var smart = GetJsonFormatter();
+            smart.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
             Assert.Multiple(() =>
             {
-                Assert.AreEqual("50.00", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
-                Assert.AreEqual("True", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
-                Assert.AreEqual("False", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
+                Assert.AreEqual("50.00", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
+                Assert.AreEqual("True", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
+                Assert.AreEqual("False", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
             });
-
-            Smart.Default.Settings.CaseSensitivity = savedSetting;
         }
 
         [Test]
         public void NS_Format_Complex_Json_CaseInsensitive()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var savedSetting = _formatter.Settings.CaseSensitivity;
-            _formatter.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
-            var result = _formatter.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
+            var smart = GetJsonFormatter();
+            smart.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
+            var result = smart.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
             Assert.AreEqual("50.00", result);
-            _formatter.Settings.CaseSensitivity = savedSetting;
         }
 
         [Test]
         public void NS_Format_List_Json()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var result = _formatter.Format("{Stores:list:{}|, |, and }", jObject);
+            var result = GetJsonFormatter().Format("{Stores:list:{}|, |, and }", jObject);
             Assert.AreEqual("Lambton Quay, and Willis Street", result);
         }
 
         [Test]
         public void NS_Format_Exception_Json()
         {
-            var savedSetting = Smart.Default.Settings.FormatErrorAction;
-            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            var smart = GetJsonFormatter();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             var jObject = JObject.Parse(JsonOneLevel);
-            Assert.Throws<FormattingException>(() => _formatter.Format("{Dummy}", jObject));
-            Smart.Default.Settings.FormatErrorAction = savedSetting;
+            Assert.Throws<FormattingException>(() => smart.Format("{Dummy}", jObject));
         }
 
         #endregion
@@ -135,7 +142,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_Null_Json()
         {
             var jObject = JsonDocument.Parse(JsonNull.Replace("'", "\"")).RootElement;
-            var result = _formatter.Format("{Name}", jObject);
+            var result = GetJsonFormatter().Format("{Name}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -143,7 +150,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_OneLevel_Json()
         {
             var jObject = JsonDocument.Parse(JsonOneLevel.Replace("'", "\"")).RootElement;
-            var result = _formatter.Format("{Name}", jObject);
+            var result = GetJsonFormatter().Format("{Name}", jObject);
             Assert.AreEqual("Doe", result);
         }
 
@@ -151,8 +158,16 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_TwoLevel_Json()
         {
             var jObject = JsonDocument.Parse(JsonTwoLevel.Replace("'", "\"")).RootElement;
-            var result = _formatter.Format("{Name.First}", jObject);
+            var result = GetJsonFormatter().Format("{Name.First}", jObject);
             Assert.AreEqual("Joe", result);
+        }
+
+        [Test]
+        public void ST_Format_TwoLevel_Nullable_Json()
+        {
+            var jObject = JsonDocument.Parse(JsonNull.Replace("'", "\"")).RootElement;
+            var result = GetJsonFormatter().Format("{Name?.First}", jObject);
+            Assert.AreEqual("", result);
         }
 
         [Test]
@@ -163,9 +178,10 @@ namespace SmartFormat.Tests.Extensions
             Smart.Default.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
             Assert.Multiple(() =>
             {
-                Assert.AreEqual("50.00", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
-                Assert.AreEqual("True", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
-                Assert.AreEqual("False", _formatter.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
+                var smart = GetJsonFormatter();
+                Assert.AreEqual("50.00", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
+                Assert.AreEqual("True", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
+                Assert.AreEqual("False", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
             });
             Smart.Default.Settings.CaseSensitivity = savedSetting;
         }
@@ -174,29 +190,27 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_Complex_Json_CaseInsensitive()
         {
             var jObject = JsonDocument.Parse(JsonComplex.Replace("'", "\"")).RootElement;
-            var savedSetting = Smart.Default.Settings.CaseSensitivity;
-            _formatter.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
-            var result = _formatter.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
+            var smart = GetJsonFormatter();
+            smart.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
+            var result = smart.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
             Assert.AreEqual("50.00", result);
-            Smart.Default.Settings.CaseSensitivity = savedSetting;
         }
 
         [Test]
         public void ST_Format_List_Json()
         {
             var jObject = JsonDocument.Parse(JsonComplex.Replace("'", "\"")).RootElement;
-            var result = _formatter.Format("{Stores:list:{}|, |, and }", jObject);
+            var result = GetJsonFormatter().Format("{Stores:list:{}|, |, and }", jObject);
             Assert.AreEqual("Lambton Quay, and Willis Street", result);
         }
 
         [Test]
         public void ST_Format_Exception_Json()
         {
-            var savedSetting = Smart.Default.Settings.FormatErrorAction;
-            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            var smart = GetJsonFormatter();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             var jObject = JsonDocument.Parse(JsonOneLevel.Replace("'", "\"")).RootElement;
-            Assert.Throws<FormattingException>(() => _formatter.Format("{Dummy}", jObject));
-            Smart.Default.Settings.FormatErrorAction = savedSetting;
+            Assert.Throws<FormattingException>(() => smart.Format("{Dummy}", jObject));
         }
 
         #endregion

--- a/src/SmartFormat.Tests/Extensions/JsonSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/JsonSourceTests.cs
@@ -50,7 +50,7 @@ namespace SmartFormat.Tests.Extensions
   ]
 }";
 
-        private SmartFormatter GetJsonFormatter()
+        private SmartFormatter GetFormatterWithJsonSource()
         {
             var smart = new SmartFormatter();
             // JsonSource MUST be registered before ReflectionSource (which is not required here)
@@ -65,7 +65,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_Null_Json()
         {
             var jObject = JObject.Parse(JsonNull);
-            var result = GetJsonFormatter().Format("{Name}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -73,7 +73,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_OneLevel_Json()
         {
             var jObject = JObject.Parse(JsonOneLevel);
-            var result = GetJsonFormatter().Format("{Name}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name}", jObject);
             Assert.AreEqual("Doe", result);
         }
 
@@ -81,7 +81,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_TwoLevel_Json()
         {
             var jObject = JObject.Parse(JsonTwoLevel);
-            var result = GetJsonFormatter().Format("{Name.First}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name.First}", jObject);
             Assert.AreEqual("Joe", result);
         }
 
@@ -89,7 +89,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_TwoLevel_Nullable_Json()
         {
             var jObject = JObject.Parse(JsonNull);
-            var result = GetJsonFormatter().Format("{Name?.First}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name?.First}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -97,7 +97,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_Complex_Json()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var smart = GetJsonFormatter();
+            var smart = GetFormatterWithJsonSource();
             smart.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
             Assert.Multiple(() =>
             {
@@ -111,7 +111,7 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_Complex_Json_CaseInsensitive()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var smart = GetJsonFormatter();
+            var smart = GetFormatterWithJsonSource();
             smart.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
             var result = smart.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
             Assert.AreEqual("50.00", result);
@@ -121,14 +121,14 @@ namespace SmartFormat.Tests.Extensions
         public void NS_Format_List_Json()
         {
             var jObject = JObject.Parse(JsonComplex);
-            var result = GetJsonFormatter().Format("{Stores:list:{}|, |, and }", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Stores:list:{}|, |, and }", jObject);
             Assert.AreEqual("Lambton Quay, and Willis Street", result);
         }
 
         [Test]
         public void NS_Format_Exception_Json()
         {
-            var smart = GetJsonFormatter();
+            var smart = GetFormatterWithJsonSource();
             smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             var jObject = JObject.Parse(JsonOneLevel);
             Assert.Throws<FormattingException>(() => smart.Format("{Dummy}", jObject));
@@ -142,7 +142,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_Null_Json()
         {
             var jObject = JsonDocument.Parse(JsonNull.Replace("'", "\"")).RootElement;
-            var result = GetJsonFormatter().Format("{Name}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -150,7 +150,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_OneLevel_Json()
         {
             var jObject = JsonDocument.Parse(JsonOneLevel.Replace("'", "\"")).RootElement;
-            var result = GetJsonFormatter().Format("{Name}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name}", jObject);
             Assert.AreEqual("Doe", result);
         }
 
@@ -158,7 +158,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_TwoLevel_Json()
         {
             var jObject = JsonDocument.Parse(JsonTwoLevel.Replace("'", "\"")).RootElement;
-            var result = GetJsonFormatter().Format("{Name.First}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name.First}", jObject);
             Assert.AreEqual("Joe", result);
         }
 
@@ -166,7 +166,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_TwoLevel_Nullable_Json()
         {
             var jObject = JsonDocument.Parse(JsonNull.Replace("'", "\"")).RootElement;
-            var result = GetJsonFormatter().Format("{Name?.First}", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Name?.First}", jObject);
             Assert.AreEqual("", result);
         }
 
@@ -178,7 +178,7 @@ namespace SmartFormat.Tests.Extensions
             Smart.Default.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
             Assert.Multiple(() =>
             {
-                var smart = GetJsonFormatter();
+                var smart = GetFormatterWithJsonSource();
                 Assert.AreEqual("50.00", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
                 Assert.AreEqual("True", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
                 Assert.AreEqual("False", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
@@ -190,7 +190,7 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_Complex_Json_CaseInsensitive()
         {
             var jObject = JsonDocument.Parse(JsonComplex.Replace("'", "\"")).RootElement;
-            var smart = GetJsonFormatter();
+            var smart = GetFormatterWithJsonSource();
             smart.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
             var result = smart.Format(CultureInfo.InvariantCulture, "{MaNuFaCtUrErS[0].PrOdUcTs[0].PrIcE:0.00}", jObject);
             Assert.AreEqual("50.00", result);
@@ -200,14 +200,14 @@ namespace SmartFormat.Tests.Extensions
         public void ST_Format_List_Json()
         {
             var jObject = JsonDocument.Parse(JsonComplex.Replace("'", "\"")).RootElement;
-            var result = GetJsonFormatter().Format("{Stores:list:{}|, |, and }", jObject);
+            var result = GetFormatterWithJsonSource().Format("{Stores:list:{}|, |, and }", jObject);
             Assert.AreEqual("Lambton Quay, and Willis Street", result);
         }
 
         [Test]
         public void ST_Format_Exception_Json()
         {
-            var smart = GetJsonFormatter();
+            var smart = GetFormatterWithJsonSource();
             smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             var jObject = JsonDocument.Parse(JsonOneLevel.Replace("'", "\"")).RootElement;
             Assert.Throws<FormattingException>(() => smart.Format("{Dummy}", jObject));

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -37,6 +37,21 @@ namespace SmartFormat.Tests.Extensions
         }
 
         [Test]
+        public void Empty_List()
+        {
+            var items = Array.Empty<string>();
+            var result = Smart.Default.Format("{0:list:{}|, |, and }", new object[] { items });
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
+        public void Null_List()
+        {
+            var result = Smart.Default.Format("{TheList?:list:{}|, |, and }", new { TheList = default(object)});
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
         public void List_of_anonymous_types_and_enumerables()
         {
             var data = new[]
@@ -143,12 +158,7 @@ namespace SmartFormat.Tests.Extensions
             formatter.SourceExtensions.Add(new DefaultSource(formatter));
             formatter.FormatterExtensions.Add(new DefaultFormatter());
 
-            Assert.Multiple(
-                () =>
-                {
-                    Assert.AreEqual("one, two, and three", formatter.Format("{0:list:{}|, |, and }", new object[] { items }));
-                    Assert.Throws<FormattingException>(() => formatter.Format("{0:list:{}|, |, and }", new { Index = 100 })); // no formatter found
-                });
+            Assert.AreEqual("one, two, and three", formatter.Format("{0:list:{}|, |, and }", new object[] { items }));
         }
 
         [TestCase("{0:{} = {Index}|, }", "A = 0, B = 1, C = 2, D = 3, E = 4")] // Index holds the current index of the iteration
@@ -159,6 +169,14 @@ namespace SmartFormat.Tests.Extensions
         {
             var args = GetArgs();
             Smart.Default.Test(new[] {format}, args, new[] {expected});
+        }
+
+        [Test]
+        public void Test_Not_An_IList_Argument()
+        {
+            Assert.That(() => Smart.Format("{0:list:{}|, |, and }", "not a list"),
+                Throws.Exception.TypeOf<FormattingException>().And.Message
+                    .Contains("No suitable Formatter"));
         }
 
         [TestCase("one", "one")]

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Extensions;
 using SmartFormat.Tests.TestUtils;
@@ -157,6 +159,41 @@ namespace SmartFormat.Tests.Extensions
         {
             var args = GetArgs();
             Smart.Default.Test(new[] {format}, args, new[] {expected});
+        }
+
+        [TestCase("one", "one")]
+        [TestCase(null, "")]
+        public void Should_Return_Indexed_List_Element(string? listElement, string expected)
+        {
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new ReflectionSource(smart) });
+            smart.AddExtensions(new IFormatter[] {new ListFormatter(smart), new DefaultFormatter()});
+            smart = Smart.CreateDefaultSmartFormat();
+
+            var numbers = new List<string?> {"dummy", listElement};
+
+            var data = new {Numbers = numbers};
+            var indexResult1 = smart.Format(">{Numbers.1}<", data); // index method 1
+            var indexResult2 = smart.Format(">{Numbers[1]}<", data); // index method 2
+            
+            Assert.That(indexResult1, Is.EqualTo($">{expected}<"));
+            Assert.That(indexResult2, Is.EqualTo($">{expected}<"));
+        }
+
+        [Test]
+        public void Null_IList_Nullable_Should_Return_Null()
+        {
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new ReflectionSource(smart) });
+            smart.AddExtensions(new IFormatter[] {new ListFormatter(smart), new DefaultFormatter()});
+            smart = Smart.CreateDefaultSmartFormat();
+            
+            var data = new {Numbers = default(object)};
+            var indexResult1 = smart.Format(">{Numbers?.0}<", data); // index method 1
+            var indexResult2 = smart.Format(">{Numbers?[0]}<", data); // index method 2
+
+            Assert.That(indexResult1, Is.EqualTo("><"));
+            Assert.That(indexResult2, Is.EqualTo("><"));
         }
     }
 }

--- a/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SmartFormat.Core.Extensions;
+using SmartFormat.Extensions;
+
+namespace SmartFormat.Tests.Extensions
+{
+    [TestFixture]
+    public class NullFormatterTests
+    {
+        private SmartFormatter GetFormatter()
+        {
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new ReflectionSource(smart) });
+            smart.AddExtensions(new IFormatter[] { new NullFormatter(), new ListFormatter(smart), new DefaultFormatter()});
+            return smart;
+        }
+
+        [Test]
+        public void Null_Without_Format_Should_Be_Empty_String()
+        {
+            var smart = GetFormatter();
+            smart.Settings.StringFormatCompatibility = false;
+            Assert.That(smart.Format("{JustNull}", new { JustNull = default(object)} ), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void Null_Without_Format_Should_Be_Empty_String_CompatibilityMode()
+        {
+            var smart = GetFormatter();
+            smart.Settings.StringFormatCompatibility = true;
+            Assert.That(smart.Format("{JustNull}", new { JustNull = default(object)} ), Is.EqualTo(string.Empty));
+        }
+
+        [TestCase("")] // empty format
+        [TestCase("nothing")]
+        public void Null_With_Format_Should_Be_Format_String(string format)
+        {
+            var smart = GetFormatter();
+            Assert.That(smart.Format($"{{JustNull:{format}}}", new { JustNull = default(object)} ), Is.EqualTo(format));
+        }
+
+        [TestCase("")] // empty format
+        [TestCase("something")]
+        public void NotNull_Should_Be_Empty_String(string format)
+        {
+            var smart = GetFormatter();
+            Assert.That(smart.Format($"{{NotNull:{format}}}", new { NotNull = ""} ), Is.EqualTo(string.Empty));
+        }
+
+        [TestCase(null)]
+        [TestCase("a string")]
+        [TestCase(new long[] {5, 6, 7})]
+        public void Format_Should_Only_Be_Output_If_Argument_Is_Null(object? value)
+        {
+            var smart = GetFormatter();
+            Assert.That(smart.Format("{TheValue:isnull:}", new {TheValue = value}), Is.EqualTo(string.Empty));
+            Assert.That(smart.Format("{TheValue:isnull:nothing}", new {TheValue = value}),
+                value == null ? Is.EqualTo("nothing") : Is.EqualTo(string.Empty));
+        }
+
+        [TestCase(null, "Argument is null")]
+        [TestCase("Argument has this value", "Argument has this value")]
+        public void Combine_NullFormatter_With_Other_Formatter(object value, string expected)
+        {
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new ISource[] { new DefaultSource(smart) });
+            smart.AddExtensions(new IFormatter[] { new NullFormatter(), new DefaultFormatter()});
+            
+            // NullFormatter will output only, if value is null
+            // DefaultFormatter will render null as string.Empty
+            var result = smart.Format($"{{0:isnull:{expected}}}{{0}}", value!);
+            
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
@@ -41,7 +41,7 @@ namespace SmartFormat.Tests.Extensions
         public void Null_With_Format_Should_Be_Format_String(string format)
         {
             var smart = GetFormatter();
-            Assert.That(smart.Format($"{{JustNull:{format}}}", new { JustNull = default(object)} ), Is.EqualTo(format));
+            Assert.That(smart.Format($"{{JustNull:isnull:{format}}}", new { JustNull = default(object)} ), Is.EqualTo(format));
         }
 
         [TestCase("")] // empty format

--- a/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
@@ -228,15 +228,15 @@ namespace SmartFormat.Tests.Extensions
 
         internal class Address
         {
-            public string Country;
-            public string City;
+            public readonly string Country = string.Empty;
+            public readonly string City = string.Empty;
         }
 
         internal class Person
         {
             public string FirstName = "first";
             public string LastName = "last";
-            public Address? Address;
+            public Address? Address = null;
         }
     }
 }

--- a/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Parsing;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
+using SmartFormat.Utilities;
 
 namespace SmartFormat.Tests.Extensions
 {
@@ -33,10 +36,9 @@ namespace SmartFormat.Tests.Extensions
 
         [TestCase("Name: {Person.FirstName} {City?.AreaCode}", true)]
         [TestCase("Name: {Person.FirstName} {City.AreaCode}", false)]
-        public void Format_With_Nullable_ValueTuples(string format, bool shouldSucceed)
+        public void Format_With_Null_Values_In_ValueTuples(string format, bool shouldSucceed)
         {
-            var addr = new DictionaryFormatterTests.Address();
-            addr.City = null;
+            var addr = new DictionaryFormatterTests.Address {City = null};
 
             var dict1 = new Dictionary<string, string> { {"dict1key", "dict1 Value"} };
             var dict2 = new Dictionary<string, string> { { "dict2key", "dict2 Value" } };
@@ -76,6 +78,16 @@ namespace SmartFormat.Tests.Extensions
             var result = formatter.Format(format, null!, (addr, dict1, dict2));
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Test_Nested_Tuples()
+        {
+            var child = (Child: "The child", ChildName: "Child name");
+            var mainWithChild = (Main: "Main", child);
+            var expected = new List<object?> { mainWithChild.Item1, child.Child, child.ChildName};
+
+            Assert.That(mainWithChild.GetValueTupleItemObjectsFlattened().ToList(), Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
@@ -118,7 +118,7 @@ namespace SmartFormat.Tests.Extensions
             public object? CurrentValue { get; }
             public string? SelectorText { get; }
             public int SelectorIndex { get; }
-            public string SelectorOperator { get; }
+            public string SelectorOperator { get; } = string.Empty;
             public object? Result { get; set; }
             public Placeholder? Placeholder { get; }
             public FormatDetails FormatDetails { get; } = (FormatDetails) null!; // dummy

--- a/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
@@ -14,33 +14,68 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Format_With_ValueTuples()
         {
-            // With SmartObjects
-            // * all objects used for Smart.Format can be collected in one place as the first argument
-            // * the format string can be written like each object would be the first argument of Smart.Format
-            // * there is no need to bother from which argument a value should come from 
-
             var addr = new DictionaryFormatterTests.Address();
             var dict1 = new Dictionary<string, string> { {"dict1key", "dict1 Value"} };
             var dict2 = new Dictionary<string, string> { { "dict2key", "dict2 Value" } };
 
             // format for ValueTuples as argument 1 to Smart.Format
-            const string format1 = "Name: {Person.FirstName} {Person.LastName}\n" +
+            const string format = "Name: {Person.FirstName} {Person.LastName}\n" +
                                   "Dictionaries: {dict1key}, {dict2key}";
+
+            var expected = $"Name: {addr.Person.FirstName} {addr.Person.LastName}\n" +
+                           $"Dictionaries: {dict1["dict1key"]}, {dict2["dict2key"]}";
+
+            var formatter = Smart.CreateDefaultSmartFormat();
+            var result = formatter.Format(format, (addr, dict1, dict2));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("Name: {Person.FirstName} {City?.AreaCode}", true)]
+        [TestCase("Name: {Person.FirstName} {City.AreaCode}", false)]
+        public void Format_With_Nullable_ValueTuples(string format, bool shouldSucceed)
+        {
+            var addr = new DictionaryFormatterTests.Address();
+            addr.City = null;
+
+            var dict1 = new Dictionary<string, string> { {"dict1key", "dict1 Value"} };
+            var dict2 = new Dictionary<string, string> { { "dict2key", "dict2 Value" } };
+
+            var expected = $"Name: {addr.Person.FirstName} {addr.City?.AreaCode}";
+
+            var formatter = Smart.CreateDefaultSmartFormat();
+
+            if (shouldSucceed)
+            {
+                var result = formatter.Format(format, (dict1, dict2, addr));
+                Assert.That(result, Is.EqualTo(expected));
+            }
+            else
+            {
+                Assert.That(() => formatter.Format(format, (dict1, dict2, addr)),
+                    Throws.Exception.TypeOf(typeof(FormattingException)));
+            }
+        }
+
+        [Test]
+        public void Format_With_ValueTuples_2nd_Argument()
+        {
+            var addr = new DictionaryFormatterTests.Address();
+            var dict1 = new Dictionary<string, string> { {"dict1key", "dict1 Value"} };
+            var dict2 = new Dictionary<string, string> { { "dict2key", "dict2 Value" } };
 
             // format for ValueTuples as argument 2 to Smart.Format:
             // works although unnecessary and leading to argument references in the format string
-            const string format2 = "Name: {1.Person.FirstName} {1.Person.LastName}\n" +
+            const string format = "Name: {1.Person.FirstName} {1.Person.LastName}\n" +
                                    "Dictionaries: {1.dict1key}, {1.dict2key}";
 
             var expected = $"Name: {addr.Person.FirstName} {addr.Person.LastName}\n" +
                            $"Dictionaries: {dict1["dict1key"]}, {dict2["dict2key"]}";
 
             var formatter = Smart.CreateDefaultSmartFormat();
-            var result1 = formatter.Format(format1, (addr, dict1, dict2));
-            var result2 = formatter.Format(format2, null!, (addr, dict1, dict2));
+            var result = formatter.Format(format, null!, (addr, dict1, dict2));
 
-            Assert.AreEqual(expected, result1);
-            Assert.AreEqual(expected, result2);
+            Assert.AreEqual(expected, result);
         }
 
         [Test]
@@ -63,15 +98,15 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Not_Invoked_With_FormattingInfo()
         {
-            Assert.IsFalse(new ValueTupleSource(new SmartFormatter()).TryEvaluateSelector(new SelectorInfo()));
+            Assert.IsFalse(new ValueTupleSource(new SmartFormatter()).TryEvaluateSelector(new PureSelectorInfo()));
         }
 
-        private class SelectorInfo : ISelectorInfo
+        private class PureSelectorInfo : ISelectorInfo
         {
             public object? CurrentValue { get; }
             public string? SelectorText { get; }
             public int SelectorIndex { get; }
-            public string? SelectorOperator { get; }
+            public string SelectorOperator { get; }
             public object? Result { get; set; }
             public Placeholder? Placeholder { get; }
             public FormatDetails FormatDetails { get; } = (FormatDetails) null!; // dummy

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -17,9 +17,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-		<PackageReference Include="NUnit" Version="3.12.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
 	</ItemGroup>
 

--- a/src/SmartFormat.Tests/TestUtils/TestHelpers.cs
+++ b/src/SmartFormat.Tests/TestUtils/TestHelpers.cs
@@ -80,51 +80,5 @@ namespace SmartFormat.Tests.TestUtils
 
             allErrors.ThrowIfNotEmpty();
         }
-
-        public static TimeSpan[] PerformanceTest(Func<string, object[], string>[] doFormats, string format, object[] args, int iterations)
-        {
-            // Do a warmup and make sure output matches:
-            string[] actuals = new string[doFormats.Length];
-            for (int i = 0; i < doFormats.Length; i++)
-            {
-                actuals[i] = doFormats[i](format, args);
-            }
-            for (int i = 0; i < doFormats.Length - 1; i++)
-            {
-                Assert.AreEqual(actuals[i], actuals[i+1],"Results don't match.");
-            }
-
-
-            // Do all the performance tests:
-            Stopwatch timer;
-            string discard;
-            TimeSpan[] results = new TimeSpan[doFormats.Length];
-            for (int i = 0; i < doFormats.Length; i++)
-            {
-                var doFormat = doFormats[i];
-                timer = new Stopwatch();
-                timer.Start();
-                for (int j = 0; j < iterations; j++)
-                {
-                    discard = doFormat(format, args);
-                }
-                timer.Stop();
-
-                results[i] = timer.Elapsed;
-            }
-            //// Do one final (empty) control test:
-            //timer = new Stopwatch();
-            //timer.Start();
-            //for (int j = 0; j < iterations; j++)
-            //{
-            //    discard = format;
-            //}
-            //timer.Stop();
-            //results[doFormats.Length] = timer.Elapsed;
-
-
-            // Return the results:
-            return results;
-        }
     }
 }

--- a/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
+++ b/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
@@ -42,7 +42,7 @@ namespace SmartFormat.Tests.Utilities
         /// </summary>
         public class ReverseFormatProvider : IFormatProvider
         {
-            public object GetFormat(Type formatType)
+            public object GetFormat(Type? formatType)
             {
                 if (formatType == typeof(ICustomFormatter)) return new ReverseFormatAndArgumentFormatter();
                 
@@ -55,9 +55,9 @@ namespace SmartFormat.Tests.Utilities
         /// </summary>
         public class ReverseFormatAndArgumentFormatter : ICustomFormatter
         {
-            public string Format(string format, object arg, IFormatProvider formatProvider)
+            public string Format(string? format, object? arg, IFormatProvider? formatProvider)
             {
-                return new string(format.Reverse().Select(c => c).ToArray()) + ": " +
+                return new string(format?.Reverse().Select(c => c).ToArray()) + ": " +
                        new string((arg as string ?? "?").Reverse().Select(c => c).ToArray());
             }
         }

--- a/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
+++ b/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
@@ -15,7 +15,6 @@ namespace SmartFormat.Tests.Utilities
         {
             var formatter = new SmartFormatter(); 
             formatter.FormatterExtensions.Add(new DefaultFormatter());
-            formatter.SourceExtensions.Add(new ReflectionSource(formatter));
             formatter.SourceExtensions.Add(new DefaultSource(formatter));
             return formatter;
         }

--- a/src/SmartFormat/Core/Extensions/IFormatter.cs
+++ b/src/SmartFormat/Core/Extensions/IFormatter.cs
@@ -10,7 +10,7 @@ namespace SmartFormat.Core.Extensions
     {
         /// <summary>
         /// An extension can be explicitly called by using any of its names.
-        /// Any extensions with "" names will be called implicitly (when no named formatter is specified).
+        /// Any extensions with empty names will be called implicitly (when no named formatter is specified).
         /// For example, "{0:default:N2}" or "{0:d:N2}" will explicitly call the "default" extension.
         /// "{0:N2}" will implicitly call the "default" extension (and other extensions, too).
         /// </summary>

--- a/src/SmartFormat/Core/Extensions/IFormattingInfo.cs
+++ b/src/SmartFormat/Core/Extensions/IFormattingInfo.cs
@@ -72,7 +72,7 @@ namespace SmartFormat.Core.Extensions
         /// Creates a child <see cref="IFormattingInfo"/> from the current <see cref="IFormattingInfo"/> instance
         /// and invokes formatting with <see cref="SmartFormatter"/> with the child as parameter.
         /// </summary>
-        void FormatAsChild(Format format, object value);
+        void FormatAsChild(Format format, object? value);
 
         /// <summary>
         /// Creates a <see cref="FormattingException" /> associated with the <see cref="IFormattingInfo.Format" />.

--- a/src/SmartFormat/Core/Extensions/ISelectorInfo.cs
+++ b/src/SmartFormat/Core/Extensions/ISelectorInfo.cs
@@ -31,7 +31,7 @@ namespace SmartFormat.Core.Extensions
 
         /// <summary>
         /// The index of the selector in a multi-part selector.
-        /// Example: {Person.Birthday.Year} has 3 seletors,
+        /// Example: {Person.Birthday.Year} has 3 selectors,
         /// and Year has a SelectorIndex of 2.
         /// </summary>
         int SelectorIndex { get; }
@@ -39,12 +39,12 @@ namespace SmartFormat.Core.Extensions
         /// <summary>
         /// The operator that came before the selector; typically "."
         /// </summary>
-        string? SelectorOperator { get; }
+        string SelectorOperator { get; }
 
         /// <summary>
         /// Sets the result of evaluating the selector.
         /// </summary>
-        object? Result { set; }
+        object? Result { get; set; }
 
         /// <summary>
         /// Contains all the details about the current placeholder.

--- a/src/SmartFormat/Core/Extensions/ISource.cs
+++ b/src/SmartFormat/Core/Extensions/ISource.cs
@@ -14,10 +14,11 @@ namespace SmartFormat.Core.Extensions
     {
         /// <summary>
         /// Evaluates the <see cref="Selector" /> based on the <see cref="ISelectorInfo.CurrentValue" />.
-        /// If this extension cannot evaluate the Selector, returns False.
-        /// Otherwise, sets the <see cref="ISelectorInfo.Result" /> and returns true.
         /// </summary>
         /// <param name="selectorInfo"></param>
+        /// <returns>If the <see cref="Selector"/> could be evaluated,
+        /// the <see cref="ISelectorInfo.Result" /> will be set and <see langword="true"/> will be returned.
+        /// </returns>
         bool TryEvaluateSelector(ISelectorInfo selectorInfo);
     }
 }

--- a/src/SmartFormat/Core/Extensions/Source.cs
+++ b/src/SmartFormat/Core/Extensions/Source.cs
@@ -1,0 +1,65 @@
+﻿//
+// Copyright (C) axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SmartFormat.Core.Parsing;
+
+namespace SmartFormat.Core.Extensions
+{
+    /// <summary>
+    /// The base class for <see cref="ISource"/> extension classes.
+    /// </summary>
+    public abstract class Source : ISource
+    {
+        /// <summary>
+        /// The instance of the current <see cref="SmartFormatter"/>.
+        /// </summary>
+        protected readonly SmartFormatter _formatter;
+
+        /// <summary>
+        /// The operator character used to indicate <c>nullable</c>.
+        /// </summary>
+        protected readonly char _nullableOperator;
+
+        /// <summary>
+        /// The general operator character used to separate <see cref="Selector"/>s.
+        /// </summary>
+        protected readonly char _selectorOperator;
+
+        /// <inheritdoc cref="ISource" />
+        protected Source(SmartFormatter formatter)
+        {
+            _formatter = formatter;
+            _nullableOperator = formatter.Settings.Parser.NullableOperator;
+            _selectorOperator = formatter.Settings.Parser.SelectorOperator;
+        }
+
+        /// <inheritdoc />
+        public virtual bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if any of the <see cref="Placeholder"/>'s <see cref="Placeholder.Selectors"/> has nullable <c>?</c> as their first operator.
+        /// </summary>
+        /// <param name="selectorInfo"></param>
+        /// <returns>
+        /// <see langword="true"/>, any of the <see cref="Placeholder"/>'s <see cref="Placeholder.Selectors"/> has nullable <c>?</c> as their first operator.
+        /// </returns>
+        /// <remarks>
+        /// The nullable operator '?' can be followed by a dot (like '?.') or a square brace (like '.[')
+        /// </remarks>
+        protected virtual bool HasNullableOperator(ISelectorInfo selectorInfo)
+        {
+            return selectorInfo.Placeholder != null &&
+                   selectorInfo.Placeholder.Selectors.Any(s =>
+                       s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _nullableOperator);
+        }
+    }
+}

--- a/src/SmartFormat/Core/Formatting/FormattingInfo.cs
+++ b/src/SmartFormat/Core/Formatting/FormattingInfo.cs
@@ -148,7 +148,7 @@ namespace SmartFormat.Core.Formatting
         /// </summary>
         /// <param name="format">The <see cref="Format"/> to use.</param>
         /// <param name="value">The value for the item in the format.</param>
-        public void FormatAsChild(Format format, object value)
+        public void FormatAsChild(Format format, object? value)
         {
             var nestedFormatInfo = CreateChild(format, value);
             // recursive method call
@@ -182,14 +182,14 @@ namespace SmartFormat.Core.Formatting
         /// <summary>
         /// Gets the operator string of the <see cref="Parsing.Selector"/> (e.g.: comma, dot).
         /// </summary>
-        public string? SelectorOperator => Selector?.Operator;
+        public string SelectorOperator => Selector?.Operator ?? string.Empty;
 
         /// <summary>
         /// Gets the result after formatting is completed.
         /// </summary>
         public object? Result { get; set; }
 
-        private FormattingInfo CreateChild(Format format, object currentValue)
+        private FormattingInfo CreateChild(Format format, object? currentValue)
         {
             return new FormattingInfo(this, FormatDetails, format, currentValue);
         }

--- a/src/SmartFormat/Core/Parsing/ParsingErrors.cs
+++ b/src/SmartFormat/Core/Parsing/ParsingErrors.cs
@@ -27,13 +27,13 @@ namespace SmartFormat.Core.Parsing
         public bool HasIssues => Issues.Count > 0;
 
         public string MessageShort =>
-            $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? "" : "s")}: {string.Join(", ", Issues.Select(i => i.Issue).ToArray())}";
+            $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? string.Empty : "s")}: {string.Join(", ", Issues.Select(i => i.Issue).ToArray())}";
 
         public override string Message
         {
             get
             {
-                var arrows = "";
+                var arrows = string.Empty;
                 var lastArrow = 0;
                 foreach (var issue in Issues)
                 {
@@ -51,7 +51,7 @@ namespace SmartFormat.Core.Parsing
                 }
 
                 return
-                    $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? "" : "s")}:\n{string.Join(", ", Issues.Select(i => i.Issue).ToArray())}\nIn: \"{result.BaseString}\"\nAt:  {arrows} ";
+                    $"The format string has {Issues.Count} issue{(Issues.Count == 1 ? string.Empty : "s")}:\n{string.Join(", ", Issues.Select(i => i.Issue).ToArray())}\nIn: \"{result.BaseString}\"\nAt:  {arrows} ";
             }
         }
 

--- a/src/SmartFormat/Core/Parsing/Placeholder.cs
+++ b/src/SmartFormat/Core/Parsing/Placeholder.cs
@@ -36,8 +36,8 @@ namespace SmartFormat.Core.Parsing
             Parent = parent;
             Selectors = new List<Selector>();
             NestedDepth = nestedDepth;
-            FormatterName = "";
-            FormatterOptionsRaw = "";
+            FormatterName = string.Empty;
+            FormatterOptionsRaw = string.Empty;
         }
 
         /// <summary>
@@ -104,11 +104,11 @@ namespace SmartFormat.Core.Parsing
                 result.Append(Alignment);
             }
 
-            if (FormatterName != "")
+            if (FormatterName != string.Empty)
             {
                 result.Append(SmartSettings.Parser.FormatterNameSeparator);
                 result.Append(FormatterName);
-                if (FormatterOptions != "")
+                if (FormatterOptions != string.Empty)
                 {
                     result.Append(SmartSettings.Parser.FormatterOptionsBeginChar);
                     result.Append(FormatterOptions);

--- a/src/SmartFormat/Core/Parsing/Selector.cs
+++ b/src/SmartFormat/Core/Parsing/Selector.cs
@@ -8,8 +8,8 @@ using SmartFormat.Core.Settings;
 namespace SmartFormat.Core.Parsing
 {
     /// <summary>
-    /// Represents a single selector in a <see cref="Placeholder" />
-    /// that comes before the colon.
+    /// Represents a single selector in a <see cref="Placeholder" />.
+    /// E.g.: {selector0.selector1?.selector2}, while "." and "?." and "?[]" are operators.
     /// </summary>
     public class Selector : FormatItem
     {
@@ -18,6 +18,20 @@ namespace SmartFormat.Core.Parsing
         /// </summary>
         internal readonly int OperatorStartIndex;
 
+        /// <summary>
+        /// Gets the length of the operator.
+        /// </summary>
+        internal int OperatorLength => StartIndex - OperatorStartIndex;
+
+        /// <summary>
+        /// Creates a new <see cref="Selector"/> instance.
+        /// </summary>
+        /// <param name="smartSettings"></param>
+        /// <param name="baseString"></param>
+        /// <param name="startIndex"></param>
+        /// <param name="endIndex"></param>
+        /// <param name="operatorStartIndex"></param>
+        /// <param name="selectorIndex"></param>
         public Selector(SmartSettings smartSettings, string baseString, int startIndex, int endIndex, int operatorStartIndex,
             int selectorIndex)
             : base(smartSettings, baseString, startIndex, endIndex)
@@ -34,11 +48,11 @@ namespace SmartFormat.Core.Parsing
         public int SelectorIndex { get; }
 
         /// <summary>
-        /// Gets the one of the operator characters as defined in <see cref="SmartSettings.Parser.OperatorChars"/>.
+        /// Gets the operator characters.
         /// </summary>
         /// <example>
-        /// The operator that came between selectors is typically a colon (".")
+        /// The operator that came between selectors is typically ("." or "?.")
         /// </example>
-        public string Operator => BaseString.Substring(OperatorStartIndex, StartIndex - OperatorStartIndex);
+        public string Operator => BaseString.Substring(OperatorStartIndex, OperatorLength);
     }
 }

--- a/src/SmartFormat/Core/Settings/ParserSettings.cs
+++ b/src/SmartFormat/Core/Settings/ParserSettings.cs
@@ -119,7 +119,7 @@ namespace SmartFormat.Core.Settings
         /// The standard operator characters.
         /// Contiguous operator characters are parsed as one operator (e.g. '?.').
         /// </summary>
-        internal IReadOnlyList<char> OperatorChars => new List<char> {SelectorOperator, AlignmentOperator, '[', ']'};
+        internal IReadOnlyList<char> OperatorChars => new List<char> {SelectorOperator, NullableOperator, AlignmentOperator, ListIndexBeginChar, ListIndexEndChar};
 
         /// <summary>
         /// The character which separates the selector for alignment. <c>E.g.: Smart.Format("Name: {name,10}")</c>
@@ -130,6 +130,13 @@ namespace SmartFormat.Core.Settings
         /// The character which separates two or more selectors <c>E.g.: "First.Second.Third"</c>
         /// </summary>
         internal char SelectorOperator { get; } = '.';
+
+        /// <summary>
+        /// The character which flags the selector as <see langword="nullable"/>.
+        /// The character after <see cref="NullableOperator"/> must be the <see cref="SelectorOperator"/>.
+        /// <c>E.g.: "First?.Second"</c>
+        /// </summary>
+        internal char NullableOperator { get; } = '?';
 
         /// <summary>
         /// Gets the character indicating the start of a <see cref="Placeholder"/>.
@@ -150,6 +157,16 @@ namespace SmartFormat.Core.Settings
         /// Gets the character indicating the end of formatter options.
         /// </summary>
         public char FormatterOptionsEndChar { get; } = ')';
+
+        /// <summary>
+        /// Gets the character indicating the begin of a list index, like in "{Numbers[0]}"
+        /// </summary>
+        internal char ListIndexBeginChar { get; } = '[';
+
+        /// <summary>
+        /// Gets the character indicating the end of a list index, like in "{Numbers[0]}"
+        /// </summary>
+        internal char ListIndexEndChar { get; } = ']';
 
         /// <summary>
         /// Characters which terminate parsing of format options.

--- a/src/SmartFormat/Extensions/ChooseFormatter.cs
+++ b/src/SmartFormat/Extensions/ChooseFormatter.cs
@@ -24,7 +24,7 @@ namespace SmartFormat.Extensions
 
             var chosenFormat = DetermineChosenFormat(formattingInfo, formats, chooseOptions);
 
-            formattingInfo.FormatAsChild(chosenFormat, formattingInfo.CurrentValue ?? string.Empty);
+            formattingInfo.FormatAsChild(chosenFormat, formattingInfo.CurrentValue);
 
             return true;
         }

--- a/src/SmartFormat/Extensions/ConditionalFormatter.cs
+++ b/src/SmartFormat/Extensions/ConditionalFormatter.cs
@@ -12,6 +12,9 @@ using SmartFormat.Utilities;
 
 namespace SmartFormat.Extensions
 {
+    /// <summary>
+    /// A class to format primitive types with condition patterns.
+    /// </summary>
     public class ConditionalFormatter : IFormatter
     {
         private static readonly Regex _complexConditionPattern
@@ -19,8 +22,10 @@ namespace SmartFormat.Extensions
                 //   Description:      and/or    comparator     value
                 RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
+        ///<inheritdoc />
         public string[] Names { get; set; } = {"conditional", "cond", string.Empty};
 
+        ///<inheritdoc />
         public bool TryEvaluateFormat(IFormattingInfo formattingInfo)
         {
             var format = formattingInfo.Format;
@@ -39,7 +44,6 @@ namespace SmartFormat.Extensions
                 current is byte || current is short || current is int || current is long
                 || current is float || current is double || current is decimal;
             // An Enum is a number too:
-
             if (currentIsNumber == false && current != null && current.GetType().GetTypeInfo().IsEnum)
                 currentIsNumber = true;
 
@@ -149,7 +153,7 @@ namespace SmartFormat.Extensions
 
         /// <summary>
         /// Evaluates a conditional format.
-        /// Each condition must start with a comparor: "&gt;/&gt;=", "&lt;/&lt;=", "=", "!=".
+        /// Each condition must start with a comparer: "&gt;/&gt;=", "&lt;/&lt;=", "=", "!=".
         /// Conditions must be separated by either "&amp;" (AND) or "/" (OR).
         /// The conditional statement must end with a "?".
         /// Examples:

--- a/src/SmartFormat/Extensions/ConditionalFormatter.cs
+++ b/src/SmartFormat/Extensions/ConditionalFormatter.cs
@@ -19,7 +19,7 @@ namespace SmartFormat.Extensions
                 //   Description:      and/or    comparator     value
                 RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
-        public string[] Names { get; set; } = {"conditional", "cond", ""};
+        public string[] Names { get; set; } = {"conditional", "cond", string.Empty};
 
         public bool TryEvaluateFormat(IFormattingInfo formattingInfo)
         {
@@ -71,7 +71,7 @@ namespace SmartFormat.Extensions
                     // If the conditional statement was true, then we can break.
                     if (conditionWasTrue)
                     {
-                        formattingInfo.FormatAsChild(outputItem, current ?? string.Empty);
+                        formattingInfo.FormatAsChild(outputItem, current);
                         return true;
                     }
                 }
@@ -143,7 +143,7 @@ namespace SmartFormat.Extensions
             var selectedParameter = parameters[paramIndex];
 
             // Output the selectedParameter:
-            formattingInfo.FormatAsChild(selectedParameter, current ?? string.Empty);
+            formattingInfo.FormatAsChild(selectedParameter, current);
             return true;
         }
 

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -16,7 +16,7 @@ namespace SmartFormat.Extensions
         /// <summary>
         /// Gets or set the names of the <see cref="DefaultFormatter"/>.
         /// </summary>
-        public string[] Names { get; set; } = {"default", "d", ""};
+        public string[] Names { get; set; } = {"default", "d", string.Empty};
 
         /// <summary>
         /// Checks, if the current value of the <see cref="ISelectorInfo"/> can be processed by the <see cref="DefaultFormatter"/>.
@@ -32,12 +32,9 @@ namespace SmartFormat.Extensions
             // instead of formatting the item:
             if (format != null && format.HasNested)
             {
-                formattingInfo.FormatAsChild(format, current ?? string.Empty);
+                formattingInfo.FormatAsChild(format, current);
                 return true;
             }
-
-            // If the object is null, we shouldn't write anything
-            if (current == null) current = "";
 
             // Use the provider to see if a CustomFormatter is available:
             var provider = formattingInfo.FormatDetails.Provider;
@@ -45,7 +42,7 @@ namespace SmartFormat.Extensions
             //  (The following code was adapted from the built-in String.Format code)
 
             //  We will try using IFormatProvider, IFormattable, and if all else fails, ToString.
-            string result; 
+            string? result; 
             if (provider?.GetFormat(typeof(ICustomFormatter)) is ICustomFormatter cFormatter)
             {
                 var formatText = format?.GetLiteralText();
@@ -60,11 +57,11 @@ namespace SmartFormat.Extensions
             // ToString:
             else
             {
-                result = current.ToString() ?? string.Empty;
+                result = current?.ToString();
             }
 
             // Output the result:
-            formattingInfo.Write(result);
+            formattingInfo.Write(result ?? string.Empty);
 
             return true;
         }

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -13,9 +13,7 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class DefaultFormatter : IFormatter
     {
-        /// <summary>
-        /// Gets or set the names of the <see cref="DefaultFormatter"/>.
-        /// </summary>
+        /// <inheritdoc/>>
         public string[] Names { get; set; } = {"default", "d", string.Empty};
 
         /// <summary>
@@ -29,8 +27,8 @@ namespace SmartFormat.Extensions
             var current = formattingInfo.CurrentValue;
 
             // If the format has nested placeholders, we process those first
-            // instead of formatting the item:
-            if (format != null && format.HasNested)
+            // instead of formatting the item.
+            if (format is {HasNested: true})
             {
                 formattingInfo.FormatAsChild(format, current);
                 return true;

--- a/src/SmartFormat/Extensions/DefaultSource.cs
+++ b/src/SmartFormat/Extensions/DefaultSource.cs
@@ -4,23 +4,29 @@
 //
 
 using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Parsing;
 using SmartFormat.Core.Settings;
 
 namespace SmartFormat.Extensions
 {
-    public class DefaultSource : ISource
+    /// <summary>
+    /// Class to evaluate an index-based <see cref="Selector"/>.
+    /// </summary>
+    public class DefaultSource : Source
     {
         private readonly SmartSettings _settings;
 
-        public DefaultSource(SmartFormatter formatter)
+        /// <summary>
+        /// CTOR.
+        /// </summary>
+        /// <param name="formatter"></param>
+        public DefaultSource(SmartFormatter formatter) : base(formatter)
         {
             _settings = formatter.Settings;
         }
 
-        /// <summary>
-        /// Performs the default index-based selector, same as string.Format.
-        /// </summary>
-        public bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        /// <inheritdoc />
+        public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
             var selector = selectorInfo.SelectorText;
             var formatDetails = selectorInfo.FormatDetails;
@@ -29,7 +35,7 @@ namespace SmartFormat.Extensions
             {
                 // Argument Index:
                 // Just like string.Format, the arg index must be in-range,
-                // should be the first item, and shouldn't have any operator:
+                // must be the first item, and shouldn't have any operator
                 if (selectorInfo.SelectorIndex == 0
                     && selectorValue < formatDetails.OriginalArgs.Count
                     && selectorInfo.SelectorOperator == string.Empty)

--- a/src/SmartFormat/Extensions/DictionarySource.cs
+++ b/src/SmartFormat/Extensions/DictionarySource.cs
@@ -10,19 +10,31 @@ using SmartFormat.Core.Extensions;
 
 namespace SmartFormat.Extensions
 {
-    public class DictionarySource : ISource
+    /// <summary>
+    /// Class to evaluate sources using <see cref="IDictionary"/>s.
+    /// </summary>
+    public class DictionarySource : Source
     {
-        public DictionarySource(SmartFormatter formatter)
+        /// <summary>
+        /// CTOR.
+        /// </summary>
+        /// <param name="formatter"></param>
+        public DictionarySource(SmartFormatter formatter) : base(formatter)
         {
-            // Add some special info to the parser:
-            formatter.Parser.AddAlphanumericSelectors(); // (A-Z + a-z)
-            formatter.Parser.AddAdditionalSelectorChars("_");
-            formatter.Parser.AddOperators(".");
         }
 
-        public bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        /// <inheritdoc />>
+        public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
             var current = selectorInfo.CurrentValue;
+            if (current is null && HasNullableOperator(selectorInfo))
+            {
+                selectorInfo.Result = null;
+                return true;
+            }
+            
+            if (current is null) return false;
+
             var selector = selectorInfo.SelectorText;
 
             // See if current is a IDictionary and contains the selector:

--- a/src/SmartFormat/Extensions/IsMatchFormatter.cs
+++ b/src/SmartFormat/Extensions/IsMatchFormatter.cs
@@ -41,7 +41,7 @@ namespace SmartFormat.Extensions
             if (formattingInfo.CurrentValue != null && regEx.IsMatch(formattingInfo.CurrentValue.ToString()!))
                 formattingInfo.FormatAsChild(formats[0], formattingInfo.CurrentValue);
             else if (formats.Count == 2)
-                formattingInfo.FormatAsChild(formats[1], formattingInfo.CurrentValue ?? string.Empty);
+                formattingInfo.FormatAsChild(formats[1], formattingInfo.CurrentValue);
 
             return true;
         }

--- a/src/SmartFormat/Extensions/JsonSource.cs
+++ b/src/SmartFormat/Extensions/JsonSource.cs
@@ -12,7 +12,7 @@ using System.Linq;
 namespace SmartFormat.Extensions
 {
     /// <summary>
-    /// Class to evaluate <see cref="Newtonsoft.Json"/> and <see cref="System.Text.Json"/>  JSON sources
+    /// Class to evaluate <see cref="Newtonsoft.Json"/> and <see cref="System.Text.Json"/> JSON sources
     /// of type <see cref="JObject"/> and <see cref="JsonElement"/>.
     /// </summary>
     public class JsonSource : Source
@@ -35,7 +35,7 @@ namespace SmartFormat.Extensions
             {
                 // NewtonSoftJson
                 JObject jsonObject => jsonObject.HasValues ? jsonObject : null,
-                JValue jasonValue => jasonValue.Value,
+                JValue jsonValue => jsonValue.Value,
                 // System.Text.Json
                 JsonElement jsonElement => jsonElement.ValueKind == JsonValueKind.Null ? null : jsonElement,
                 _ => selectorInfo.CurrentValue
@@ -46,7 +46,9 @@ namespace SmartFormat.Extensions
                 selectorInfo.Result = null;
                 return true;
             }
-            
+
+            if (current is null) return false;
+
             // Note: Operators are processed by ListFormatter
             return selectorInfo.CurrentValue switch
             {
@@ -85,9 +87,7 @@ namespace SmartFormat.Extensions
             // Note: Operators are processed by ListFormatter
             public static bool TryEvaluateSelector(ISelectorInfo selectorInfo)
             {
-                if (selectorInfo.CurrentValue is null) return false;
-
-                var jsonElement = (JsonElement) selectorInfo.CurrentValue;
+                if (selectorInfo.CurrentValue is not JsonElement jsonElement) return false;
             
                 var je = jsonElement.Clone();
                 JsonElement targetElement;

--- a/src/SmartFormat/Extensions/NullFormatter.cs
+++ b/src/SmartFormat/Extensions/NullFormatter.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (C) axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using SmartFormat.Core.Extensions;
+
+namespace SmartFormat.Extensions
+{
+    /// <summary>
+    /// The class formats <see langword="null"/> values.
+    /// </summary>
+    public class NullFormatter : IFormatter
+    {
+        /// <inheritdoc />
+        public string[] Names { get; set; } = {"isnull"};
+
+        /// <inheritdoc />
+        public bool TryEvaluateFormat(IFormattingInfo formattingInfo)
+        {
+            var format = formattingInfo.Format;
+            var current = formattingInfo.CurrentValue;
+
+            switch (current)
+            {
+                case null when format is not null:
+                    formattingInfo.Write(format.GetLiteralText());
+                    break;
+                case null:
+                    formattingInfo.Write(string.Empty);
+                    break;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/SmartFormat/Extensions/NullFormatter.cs
+++ b/src/SmartFormat/Extensions/NullFormatter.cs
@@ -28,13 +28,11 @@ namespace SmartFormat.Extensions
             {
                 case null when format is not null:
                     formattingInfo.Write(format.GetLiteralText());
-                    break;
-                case null:
+                    return true;
+                default:
                     formattingInfo.Write(string.Empty);
-                    break;
+                    return true;
             }
-
-            return true;
         }
     }
 }

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -32,7 +32,7 @@ namespace SmartFormat.Extensions
 
         public string DefaultTwoLetterISOLanguageName { get; set; }
 
-        public string[] Names { get; set; } = {"plural", "p", ""};
+        public string[] Names { get; set; } = {"plural", "p", string.Empty};
 
         public bool TryEvaluateFormat(IFormattingInfo formattingInfo)
         {

--- a/src/SmartFormat/Extensions/ReflectionSource.cs
+++ b/src/SmartFormat/Extensions/ReflectionSource.cs
@@ -14,6 +14,7 @@ namespace SmartFormat.Extensions
     /// <summary>
     /// Class to evaluate sources using <see cref="System.Reflection"/>.
     /// A type cache is used in order to reduce reflection calls.
+    /// Note: Reflection is also used for strings to invoke parameterless methods like ToLower().
     /// </summary>
     public class ReflectionSource : Source
     {
@@ -34,7 +35,7 @@ namespace SmartFormat.Extensions
         {
             const BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
             var current = selectorInfo.CurrentValue;
-
+            
             if (current is null && HasNullableOperator(selectorInfo))
             {
                 selectorInfo.Result = null;

--- a/src/SmartFormat/Extensions/TemplateFormatter.cs
+++ b/src/SmartFormat/Extensions/TemplateFormatter.cs
@@ -59,7 +59,7 @@ namespace SmartFormat.Extensions
                 return false;
             }
 
-            formattingInfo.FormatAsChild(template, formattingInfo.CurrentValue ?? string.Empty);
+            formattingInfo.FormatAsChild(template, formattingInfo.CurrentValue);
             return true;
         }
 

--- a/src/SmartFormat/Extensions/TimeFormatter.cs
+++ b/src/SmartFormat/Extensions/TimeFormatter.cs
@@ -12,7 +12,7 @@ namespace SmartFormat.Extensions
 {
     public class TimeFormatter : IFormatter
     {
-        public string[] Names { get; set; } = {"timespan", "time", "t", ""};
+        public string[] Names { get; set; } = {"timespan", "time", "t", string.Empty};
 
         #region Constructors
 

--- a/src/SmartFormat/Extensions/ValueTupleSource.cs
+++ b/src/SmartFormat/Extensions/ValueTupleSource.cs
@@ -3,32 +3,48 @@
 // Licensed under the MIT license.
 //
 
+using System;
 using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Utilities;
 
 namespace SmartFormat.Extensions
 {
-    public class ValueTupleSource : ISource
+    /// <summary>
+    /// Class to evaluate <see cref="ValueTuple{T}"/>s.
+    /// With ValueTuples
+    /// a) all objects used for Smart.Format can be collected in one place as the first argument
+    /// b) the format string can be written like each object would be the first argument of Smart.Format
+    /// c) there is no need to bother from which argument a value should come from 
+    /// </summary>
+    public class ValueTupleSource : Source
     {
-        private readonly SmartFormatter _formatter;
-
-        public ValueTupleSource(SmartFormatter formatter)
+        /// <summary>
+        /// CTOR.
+        /// </summary>
+        /// <param name="formatter"></param>
+        public ValueTupleSource(SmartFormatter formatter) : base(formatter)
         {
-            _formatter = formatter;
         }
 
-        public bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        /// <inheritdoc />
+        public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
-            if (!(selectorInfo is FormattingInfo formattingInfo)) return false;
+            if (selectorInfo is not FormattingInfo formattingInfo) return false;
             if (!(formattingInfo.CurrentValue != null && formattingInfo.CurrentValue.IsValueTuple())) return false;
 
             var savedCurrentValue = formattingInfo.CurrentValue;
             foreach (var obj in formattingInfo.CurrentValue.GetValueTupleItemObjectsFlattened())
             {
+                formattingInfo.CurrentValue = obj;
+                if (obj is null && HasNullableOperator(selectorInfo))
+                {
+                    selectorInfo.Result = null;
+                    return true;
+                }
+
                 foreach (var sourceExtension in _formatter.SourceExtensions)
                 {
-                    formattingInfo.CurrentValue = obj;
                     var handled = sourceExtension.TryEvaluateSelector(formattingInfo);
                     if (handled)
                     {

--- a/src/SmartFormat/Extensions/ValueTupleSource.cs
+++ b/src/SmartFormat/Extensions/ValueTupleSource.cs
@@ -37,11 +37,6 @@ namespace SmartFormat.Extensions
             foreach (var obj in formattingInfo.CurrentValue.GetValueTupleItemObjectsFlattened())
             {
                 formattingInfo.CurrentValue = obj;
-                if (obj is null && HasNullableOperator(selectorInfo))
-                {
-                    selectorInfo.Result = null;
-                    return true;
-                }
 
                 foreach (var sourceExtension in _formatter.SourceExtensions)
                 {

--- a/src/SmartFormat/Extensions/XElementFormatter.cs
+++ b/src/SmartFormat/Extensions/XElementFormatter.cs
@@ -11,7 +11,7 @@ namespace SmartFormat.Extensions
 {
     public class XElementFormatter : IFormatter
     {
-        public string[] Names { get; set; } = {"xelement", "xml", "x", ""};
+        public string[] Names { get; set; } = {"xelement", "xml", "x", string.Empty};
 
         public bool TryEvaluateFormat(IFormattingInfo formattingInfo)
         {

--- a/src/SmartFormat/Extensions/XmlSource.cs
+++ b/src/SmartFormat/Extensions/XmlSource.cs
@@ -9,25 +9,30 @@ using SmartFormat.Core.Extensions;
 
 namespace SmartFormat.Extensions
 {
-    public class XmlSource : ISource
+    /// <summary>
+    /// Class to evaluate sources of type <see cref="XElement"/>.
+    /// </summary>
+    public class XmlSource : Source
     {
-        public XmlSource(SmartFormatter formatter)
+        /// <summary>
+        /// CTOR.
+        /// </summary>
+        /// <param name="formatter"></param>
+        public XmlSource(SmartFormatter formatter) : base(formatter)
         {
-            // Add some special info to the parser:
-            formatter.Parser.AddAlphanumericSelectors(); // (A-Z + a-z)
-            formatter.Parser.AddAdditionalSelectorChars("_");
-            formatter.Parser.AddOperators(".");
         }
 
-        public bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        /// <inheritdoc />
+        public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
-            var element = selectorInfo.CurrentValue as XElement;
-            if (element != null)
+            if (selectorInfo.CurrentValue is XElement element)
             {
                 var selector = selectorInfo.SelectorText;
                 // Find elements that match a selector
-                var selectorMatchedElements = element.Elements()
-                    .Where(x => x.Name.LocalName == selector).ToList();
+                var selectorMatchedElements =
+                    element.Elements()
+                        .Where(x => x.Name.LocalName == selector)
+                        .ToList();
                 if (selectorMatchedElements.Any())
                 {
                     selectorInfo.Result = selectorMatchedElements;

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -60,11 +60,11 @@ namespace SmartFormat
             // Note, the order is important; the extensions
             // will be executed in this order:
 
-            var listFormatter = new ListFormatter(formatter);
+            var listSourceAndFormatter = new ListFormatter(formatter);
 
             // sources for specific types must be in the list before ReflectionSource
             formatter.AddExtensions(
-                (ISource) listFormatter, // ListFormatter MUST be first
+                (ISource) listSourceAndFormatter, // ListFormatter MUST be the first source extension
                 new DictionarySource(formatter),
                 new ValueTupleSource(formatter),
                 new JsonSource(formatter),
@@ -75,7 +75,8 @@ namespace SmartFormat
                 new DefaultSource(formatter)
             );
             formatter.AddExtensions(
-                (IFormatter) listFormatter,
+                new NullFormatter(),
+                (IFormatter) listSourceAndFormatter,
                 new PluralLocalizationFormatter("en"),
                 new ConditionalFormatter(),
                 new TimeFormatter("en"),

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -75,7 +75,6 @@ namespace SmartFormat
                 new DefaultSource(formatter)
             );
             formatter.AddExtensions(
-                new NullFormatter(),
                 (IFormatter) listSourceAndFormatter,
                 new PluralLocalizationFormatter("en"),
                 new ConditionalFormatter(),

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -365,7 +365,12 @@ namespace SmartFormat
             var firstSelector = true;
             foreach (var selector in formattingInfo.Placeholder.Selectors)
             {
+                // Don't evaluate selectors empty
+                // (used e.g. for Settings.Parser.NullableOperator and Settings.Parser.ListIndexEndChar final operators)
+                if(selector.Length == 0) continue;
+                
                 formattingInfo.Selector = selector;
+
                 // If we have an alignment selector, we set Alignment for its placeholder and move on
                 if (TrySetPlaceholderAlignment(formattingInfo)) continue;
                 formattingInfo.Result = null;

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -55,18 +55,6 @@ namespace SmartFormat
         public List<IFormatter> FormatterExtensions { get; }
 
         /// <summary>
-        /// Gets all names of registered formatter extensions which are not empty.
-        /// </summary>
-        /// <returns></returns>
-        public string[] GetNotEmptyFormatterExtensionNames()
-        {
-            var names = new List<string>();
-            foreach (var extension in FormatterExtensions)
-                names.AddRange(extension.Names.Where(n => n != string.Empty).ToArray());
-            return names.ToArray();
-        }
-
-        /// <summary>
         /// Adds each extensions to this formatter.
         /// Each extension must implement ISource.
         /// </summary>
@@ -85,7 +73,6 @@ namespace SmartFormat
         {
             FormatterExtensions.InsertRange(0, formatterExtensions);
         }
-
 
         /// <summary>
         /// Searches for a Source Extension of the given type, and returns it.

--- a/src/SmartFormat/Utilities/TupleExtensions.cs
+++ b/src/SmartFormat/Utilities/TupleExtensions.cs
@@ -57,13 +57,6 @@ namespace SmartFormat.Utilities
         public static IEnumerable<object?> GetValueTupleItemObjects(this object tuple) => GetValueTupleItemFields(tuple.GetType()).Select(f => f.GetValue(tuple));
 
         /// <summary>
-        /// A list of <see cref="Type"/>s for the fields of a <see cref="ValueTuple"/>.
-        /// </summary>
-        /// <param name="tupleType"></param>
-        /// <returns>Returns of list of <see cref="Type"/>s with the fields of a <see cref="ValueTuple"/>.</returns>
-        public static IEnumerable<Type> GetValueTupleItemTypes(this Type tupleType) => GetValueTupleItemFields(tupleType).Select(f => f.FieldType);
-
-        /// <summary>
         /// A list of <see cref="FieldInfo"/>s with the fields of a <see cref="ValueTuple"/>.
         /// </summary>
         /// <param name="tupleType"></param>
@@ -83,6 +76,11 @@ namespace SmartFormat.Utilities
             return items;
         }
 
+        /// <summary>
+        /// Gets all <see cref="object"/>s of a <see cref="ValueTuple"/> as a flattened list of objects.
+        /// </summary>
+        /// <param name="tuple"></param>
+        /// <returns>All <see cref="object"/>s of a <see cref="ValueTuple"/> as a flattened list of objects.</returns>
         public static IEnumerable<object?> GetValueTupleItemObjectsFlattened(this object tuple)
         {
             foreach (var theTuple in tuple.GetValueTupleItemObjects())


### PR DESCRIPTION
#### Introduced Nullable Notation

The C# like `nullable` notation allows to display `Nullable<T>` types, depending on whether a variable contains the underlying type's value or `null`. The SmartFormat notation is `"{SomeNullable?.Property}"`. If `SomeNullable` is null, the expression is evaluated as `string.empty`.

In this context the `NullFormatter` was introduced. It outputs a custom string literal, if the variable is `null`, else `string.empty`.

Putting both together:

```Csharp
var smart = new SmartFormatter();
smart.AddExtensions(new IFormatter[] { new NullFormatter() });
```
The variable is `null`:
```Csharp
// nullResult: "This value is null"
var nullResult = smart.Format("{TheValue:isnull:This value is null}", new {TheValue = null});
// valueResult: string.Empty
var valueResult = smart.Format("{TheValue?}", new {TheValue = null});
```
The variable is a `string` value:
```Csharp
// nullResult: string.Empty
nullResult = smart.Format("{TheValue:isnull:This value is null}", new {TheValue = "My string value"});
// valueResult: "My string value"
valueResult = smart.Format("{TheValue?}", new {TheValue = "My string value"});
```
In the most simple scenario, both evaluations can also be combined with the `ChooseFormatter`:
```Csharp
// result: "This value is null" or the string value
var result = smart.Format("{TheValue?:choose(null):This value is null|{}}}", new {TheValue = null});
```
In more complex scenarios, you will, however, use the nullable notation together with other formatter extensions, like a `ListFormatter`.

**Note:** Trying to evaluate `null` without the nullable operator will result in a formatting exception. This is the same behavior as in SmartFormat 2.x.

Changes connected to nullable notation:
* Source extension should have `Source` as the abstract base class, instead of `ISource`.
* Source extensions should check for `null` values together with the nullable operator and return `true` in the `bool TryEvaluateSelector(ISelectorInfo selectorInfo)` method.
* The `Parser` accepts `?` as another standard operator.
* The nullable operator can also be used evaluating a list index, e.g. `"{TheList?[1]}"`.
