### PR TITLE
String as i source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,62 @@
 Latest Changes
 ====
 
-v3.0.0-alpha-14
+v3.0.0-alpha-15
 ===
 
 ### Current changes merged into the `version/v3.0` branch:
+
+#### Added `StringSource` as another `ISource`
+
+`StringSource` adds the following selector names, which have before been implemented with `ReflectionSource`:
+* Length
+* ToUpper
+* ToUpperInvariant
+* ToLower
+* ToLowerInvariant
+* Trim
+* TrimStart
+* TrimEnd
+* ToCharArray
+
+Additionally, the following selector names are implemented:
+* Capitalize
+* CapitalizeWords
+* FromBase64
+* ToBase64
+
+All these selector names may linked. Example with indexed placeholders:
+```CSharp
+Smart.Format("{0.ToLower.TrimStart.TrimEnd.ToBase64}", " ABCDE ");
+// result: "YWJjZGU="
+```
+This also works for named placeholders.
+
+**Note**: `ReflectionSource` does not evaluate `string`s any more.
+
+The new formatter privates additional funcionality and with with reflection caching, performance is 13% better.
+
+```
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
+.NET Core SDK=5.0.202
+  [Host]        : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+
+Job=.NET Core 5.0  Runtime=.NET Core 5.0
+
+|             Method |     N |        Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 |   Allocated |
+|------------------- |------ |------------:|----------:|----------:|----------:|------:|------:|------------:|
+| DirectMemberAccess |  1000 |    261.5 us |   5.13 us |   8.71 us |   20.9961 |     - |     - |   171.88 KB |
+|     SfStringSource |  1000 |  2,727.5 us |  10.42 us |   9.75 us |    207.03 |     - |     - |  1695.31 KB |
+|  SfCacheReflection |  1000 |  3,712.0 us |  67.06 us |  62.73 us |  214.8438 |     - |     - |  1757.81 KB |
+|SfNoCacheReflection |  1000 | 13,091.9 us | 129.38 us | 121.02 us |  781.2500 |     - |     - |  6468.75 KB |
+|                    |       |             |           |           |           |       |       |             |
+| DirectMemberAccess | 10000 |  2,519.2 us |  49.85 us |  53.34 us |  207.0313 |     - |     - |  1718.75 KB |
+|     SfStringSource | 10000 | 27,612.5 us |  68.50 us |  64.08 us | 2062.5000 |     - |     - | 16953.13 KB |
+|  SfCacheReflection | 10000 | 36,312.6 us | 438.96 us |  389.12us | 2142.8571 |     - |     - | 17578.13 KB |
+|SfNoCacheReflection | 10000 |130,049.2 us |1,231.06us |1,027.99us | 7750.0000 |     - |     - | 64687.81 KB |
+```
 
 #### JSON Source ([#177](https://github.com/axuno/SmartFormat/pull/177))
 

--- a/src/SmartFormat.Performance/ReflectionVsStringSource.cs
+++ b/src/SmartFormat.Performance/ReflectionVsStringSource.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Newtonsoft.Json.Linq;
+using SmartFormat.Core.Formatting;
+using SmartFormat.Extensions;
+
+namespace SmartFormat.Performance
+{
+    /*
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
+.NET Core SDK=5.0.202
+  [Host]        : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+
+Job=.NET Core 5.0  Runtime=.NET Core 5.0
+
+|             Method |     N |        Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 |   Allocated |
+|------------------- |------ |------------:|----------:|----------:|----------:|------:|------:|------------:|
+| DirectMemberAccess |  1000 |    261.5 us |   5.13 us |   8.71 us |   20.9961 |     - |     - |   171.88 KB |
+|     SfStringSource |  1000 |  2,727.5 us |  10.42 us |   9.75 us |    207.03 |     - |     - |  1695.31 KB |
+|  SfCacheReflection |  1000 |  3,712.0 us |  67.06 us |  62.73 us |  214.8438 |     - |     - |  1757.81 KB |
+|SfNoCacheReflection |  1000 | 13,091.9 us | 129.38 us | 121.02 us |  781.2500 |     - |     - |  6468.75 KB |
+|                    |       |             |           |           |           |       |       |             |
+| DirectMemberAccess | 10000 |  2,519.2 us |  49.85 us |  53.34 us |  207.0313 |     - |     - |  1718.75 KB |
+|     SfStringSource | 10000 | 27,612.5 us |  68.50 us |  64.08 us | 2062.5000 |     - |     - | 16953.13 KB |
+|  SfCacheReflection | 10000 | 36,312.6 us | 438.96 us |  389.12us | 2142.8571 |     - |     - | 17578.13 KB |
+|SfNoCacheReflection | 10000 |130,049.2 us |1,231.06us |1,027.99us | 7750.0000 |     - |     - | 64687.81 KB |
+
+* Legends *
+  N         : Value of the 'N' parameter
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Ratio     : Mean of the ratio distribution ([Current]/[Baseline])
+  RatioSD   : Standard deviation of the ratio distribution ([Current]/[Baseline])
+  Gen 0     : GC Generation 0 collects per 1000 operations
+  Gen 1     : GC Generation 1 collects per 1000 operations
+  Gen 2     : GC Generation 2 collects per 1000 operations
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 us      : 1 Microsecond (0.000001 sec)
+        */
+
+    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
+    [MemoryDiagnoser]
+    // [RPlotExporter]
+    public class ReflectionVsStringSource
+    {
+        private const string _formatString = "Address: {0.ToUpper} {1.ToLower}, {2.Trim}";
+
+        private readonly SmartFormatter _reflectionSourceFormatter;
+        private readonly SmartFormatter _stringSourceFormatter;
+        
+        private readonly Address _address = new Address();
+
+        private FormatCache _formatCacheLiteral;
+
+        public ReflectionVsStringSource()
+        {
+            _reflectionSourceFormatter = new SmartFormatter();
+            _reflectionSourceFormatter.AddExtensions(
+                new ReflectionSource(_reflectionSourceFormatter),
+                new DefaultSource(_reflectionSourceFormatter)
+            );
+            _reflectionSourceFormatter.AddExtensions(
+                new DefaultFormatter()
+            );
+
+            _stringSourceFormatter = new SmartFormatter();
+            _stringSourceFormatter.AddExtensions(
+                new StringSource(_stringSourceFormatter),
+                new DefaultSource(_stringSourceFormatter)
+            );
+            _stringSourceFormatter.AddExtensions(
+                new DefaultFormatter()
+            );
+
+            var parsedFormat = _stringSourceFormatter.Parser.ParseFormat(_formatString);
+            _formatCache = new FormatCache(parsedFormat);
+
+        }
+
+        [Params(1000, 10000)]
+        public int N;
+
+        private readonly FormatCache _formatCache;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+        }
+
+        [Benchmark]
+        public void DirectMemberAccess()
+        {
+            for (var i = 0; i < N; i++)
+            {
+                _ = string.Format("Address: {0} {1}, {2}", _address.City.ZipCode.ToUpper(),
+                    _address.City.Name.ToLower(), _address.City.AreaCode.Trim());
+            }
+        }
+
+        [Benchmark]
+        public void SfCacheReflectionSource()
+        {
+            for (var i = 0; i < N; i++)
+            {
+                _ = _reflectionSourceFormatter.FormatWithCache(ref _formatCacheLiteral,"Address: {0} {1}, {2}", _address.City.ZipCode,
+                    _address.City.Name, _address.City.AreaCode);
+            }
+        }
+
+        [Benchmark]
+        public void SfWithStringSource()
+        {
+            for (var i = 0; i < N; i++)
+            {
+                _ = _stringSourceFormatter.FormatWithCache(ref _formatCacheLiteral,"Address: {0} {1}, {2}", _address.City.ZipCode,
+                    _address.City.Name, _address.City.AreaCode);
+            }
+        }
+
+        public class Address
+        {
+            public CityDetails City { get; set; } = new CityDetails();
+            public PersonDetails Person { get; set; } = new PersonDetails();
+
+            public Dictionary<string, object> ToDictionary()
+            {
+                var d = new Dictionary<string, object>
+                {
+                    { nameof(City), City.ToDictionary() },
+                    { nameof(Person), Person.ToDictionary() }
+                };
+                return d;
+            }
+
+            public JObject ToJson()
+            {
+                return JObject.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(this));
+            }
+
+            public class CityDetails
+            {
+                public string Name { get; set; } = "New York";
+                public string ZipCode { get; set; } = "00501";
+                public string AreaCode { get; set; } = "631";
+
+                public Dictionary<string, string> ToDictionary()
+                {
+                    return new()
+                    {
+                        {nameof(Name), Name},
+                        {nameof(ZipCode), ZipCode},
+                        {nameof(AreaCode), AreaCode}
+                    };
+                }
+            }
+
+            public class PersonDetails
+            {
+                public string FirstName { get; set; } = "John";
+                public string LastName { get; set; } = "Doe";
+                public Dictionary<string, string> ToDictionary()
+                {
+                    return new()
+                    {
+                        {nameof(FirstName), FirstName},
+                        {nameof(LastName), LastName}
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -162,7 +162,7 @@ namespace SmartFormat.Tests.Extensions
         }
 
         [TestCase("{0:{} = {Index}|, }", "A = 0, B = 1, C = 2, D = 3, E = 4")] // Index holds the current index of the iteration
-        [TestCase("{1:{Index}: {ToCharArray:{} = {Index}|, }|; }", "0: O = 0, n = 1, e = 2; 1: T = 0, w = 1, o = 2; 2: T = 0, h = 1, r = 2, e = 3, e = 4; 3: F = 0, o = 1, u = 2, r = 3; 4: F = 0, i = 1, v = 2, e = 3")] // Index can be nested
+        [TestCase("{1:{Index}: {ToCharArray:{} = {Index}|, }|; }", "0: O = 0, n = 1, e = 2; 1: T = 0, w = 1, o = 2; 2: T = 0, h = 1, r = 2, e = 3, e = 4; 3: F = 0, o = 1, u = 2, r = 3; 4: F = 0, i = 1, v = 2, e = 3")] // Index can be nested, ToCharArray() requires StringSource or ReflectionSource
         [TestCase("{0:{} = {1.Index}|, }", "A = One, B = Two, C = Three, D = Four, E = Five")] // Index is used to synchronize 2 lists
         [TestCase("{Index}", "-1")] // Index can be used out-of-context, but should always be -1
         public void TestIndex(string format, string expected)

--- a/src/SmartFormat.Tests/Extensions/StringSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/StringSourceTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SmartFormat.Core.Extensions;
+using SmartFormat.Extensions;
+
+namespace SmartFormat.Tests.Extensions
+{
+    [TestFixture]
+    public class StringSourceTests
+    {
+        private SmartFormatter GetSimpleFormatter()
+        {
+            var smart = new SmartFormatter();
+            smart.SourceExtensions.AddRange(new ISource[]{new StringSource(smart), new DefaultSource(smart)});
+            smart.FormatterExtensions.AddRange(new IFormatter[] {new DefaultFormatter()});
+            return smart;
+        }
+
+        [TestCase("{0.Length}", "7")]
+        [TestCase("{0.ToUpper}", " ABCDE ")]
+        [TestCase("{0.ToUpperInvariant}", " ABCDE ")]
+        [TestCase("{0.ToLower}", " abcde ")]
+        [TestCase("{0.ToLowerInvariant}", " abcde ")]
+        [TestCase("{0.ToUpper.Trim}", "ABCDE")]
+        [TestCase("{0.ToLower.TrimStart.TrimEnd}", "abcde")]
+        [TestCase("{0.TrimStart.TrimEnd.ToLower}", "abcde")]
+        public void Parameterless_String_Methods_Should_Be_Equal_DotNet(string format, string expected)
+        {
+            Assert.That(GetSimpleFormatter().Format(format, " aBcDe "), Is.EqualTo(expected));
+        }
+
+        [TestCase("{0.Capitalize}", "", "")]
+        [TestCase("{0.Capitalize}", "A", "A")]
+        [TestCase("{0.Capitalize}", "a", "A")]
+        [TestCase("{0.Capitalize}", "abc", "Abc")]
+        [TestCase("{0.Capitalize}", "aBcd", "ABcd")]
+        [TestCase("{0.CapitalizeWords}", "", "")]
+        [TestCase("{0.CapitalizeWords}", "A A", "A A")]
+        [TestCase("{0.CapitalizeWords}", "a a", "A A")]
+        [TestCase("{0.CapitalizeWords}", "abc abc", "Abc Abc")]
+        [TestCase("{0.CapitalizeWords}", "aBcd aBcd", "ABcd ABcd")]
+        [TestCase("{0.ToBase64}", "a", "YQ==")]
+        [TestCase("{0.FromBase64}", "YWJj", "abc")]
+        public void SmartFormat_Parameterless_String_Methods(string format, string arg, string expected)
+        {
+            Assert.That(GetSimpleFormatter().Format(format, arg), Is.EqualTo(expected));
+        }
+
+        [TestCase("{0.Capitalize}", "abc", "Abc")]
+        [TestCase("{0.CapitalizeWords}", "abc abc", "Abc Abc")]
+        public void SmartFormat_Parameterless_String_Method_With_Culture(string format, string arg, string expected)
+        {
+            Assert.That(GetSimpleFormatter().Format(CultureInfo.InvariantCulture, format, arg), Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/SmartFormat/Extensions/DefaultSource.cs
+++ b/src/SmartFormat/Extensions/DefaultSource.cs
@@ -28,7 +28,7 @@ namespace SmartFormat.Extensions
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
-            var selector = selectorInfo.SelectorText;
+            var selector = selectorInfo.SelectorText ?? string.Empty;
             var formatDetails = selectorInfo.FormatDetails;
 
             if (int.TryParse(selector, out var selectorValue))

--- a/src/SmartFormat/Extensions/ReflectionSource.cs
+++ b/src/SmartFormat/Extensions/ReflectionSource.cs
@@ -41,8 +41,9 @@ namespace SmartFormat.Extensions
                 selectorInfo.Result = null;
                 return true;
             }
-            
-            if (current is null) return false;
+
+            // strings are processed by StringSource which should be evaluated before ReflectionSource
+            if (current is null or string) return false; 
             
             var selector = selectorInfo.SelectorText;
             

--- a/src/SmartFormat/Extensions/StringSource.cs
+++ b/src/SmartFormat/Extensions/StringSource.cs
@@ -1,0 +1,139 @@
+﻿//
+// Copyright (C) axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Formatting;
+using SmartFormat.Core.Parsing;
+using SmartFormat.Core.Settings;
+
+namespace SmartFormat.Extensions
+{
+    /// <summary>
+    /// Class to evaluate a <see cref="Selector"/> with a <see langword="string"/> as <see cref="ISelectorInfo.CurrentValue"/>.
+    /// </summary>
+    public class StringSource : Source
+    {
+        private readonly SmartSettings _settings;
+
+        /// <summary>
+        /// CTOR.
+        /// </summary>
+        /// <param name="formatter"></param>
+        public StringSource(SmartFormatter formatter) : base(formatter)
+        {
+            _settings = formatter.Settings;
+        }
+
+        /// <inheritdoc />
+        public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
+        {
+            if (selectorInfo.CurrentValue is null && HasNullableOperator(selectorInfo))
+            {
+                selectorInfo.Result = null;
+                return true;
+            }
+
+            var selector = selectorInfo.SelectorText ?? string.Empty;
+            if (selectorInfo.CurrentValue is not string current) return false;
+
+            switch (selector)
+            {
+                // build-in string methods
+                case { } when string.Equals("Length", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.Length;
+                    return true;
+                case { } when string.Equals("ToUpper", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.ToUpper(GetCulture(selectorInfo.FormatDetails));
+                    return true;
+                case { } when string.Equals("ToUpperInvariant", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.ToUpperInvariant();
+                    return true;
+                case { } when string.Equals("ToLower", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.ToLower(GetCulture(selectorInfo.FormatDetails));
+                    return true;
+                case { } when string.Equals("ToLowerInvariant", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.ToLowerInvariant();
+                    return true;
+                case { } when string.Equals("Trim", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.Trim();
+                    return true;
+                case { } when string.Equals("TrimStart", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.TrimStart();
+                    return true;
+                case { } when string.Equals("TrimEnd", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.TrimEnd();
+                    return true;
+                case { } when string.Equals("ToCharArray", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = current.ToCharArray();
+                    return true;
+                
+                // Smart.Format methods
+                case { } when string.Equals("Capitalize", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    if (current.Length < 1 || char.IsUpper(current[0]))
+                        selectorInfo.Result = current;
+                    else if (current.Length < 2)
+                        selectorInfo.Result = char.ToUpper(current[0], GetCulture(selectorInfo.FormatDetails));
+                    else
+                        selectorInfo.Result = char.ToUpper(current[0], GetCulture(selectorInfo.FormatDetails)) + current.Substring(1);
+                    
+                    return true;
+                case { } when string.Equals("CapitalizeWords", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = CapitalizeWords(current, selectorInfo);
+                    return true;
+                case { } when string.Equals("ToBase64", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = Convert.ToBase64String(Encoding.UTF8.GetBytes(current));
+                    return true;
+                case { } when string.Equals("FromBase64", selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()):
+                    selectorInfo.Result = Encoding.UTF8.GetString(Convert.FromBase64String(current));
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Converts the first character of each word to an uppercase character.
+        /// </summary>
+        private static string CapitalizeWords(string text, ISelectorInfo selectorInfo)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            var textArray = text.ToCharArray();
+            var previousSpace = true;
+            for (var i = 0; i < textArray.Length; i++)
+            {
+                var c = textArray[i];
+                if (char.IsWhiteSpace(c))
+                {
+                    previousSpace = true;
+                }
+                else if (previousSpace && char.IsLetter(c))
+                {
+                    textArray[i] = char.ToUpper(c, GetCulture(selectorInfo.FormatDetails));
+                    previousSpace = false;
+                }
+            }
+
+            return new string(textArray);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static CultureInfo GetCulture(FormatDetails formatDetails)
+        {
+            if (formatDetails.Provider is CultureInfo info)
+                return info;
+
+            return CultureInfo.CurrentCulture;
+        }
+    }
+}

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -109,7 +109,8 @@ namespace SmartFormat
 
             // sources for specific types must be in the list before ReflectionSource
             formatter.AddExtensions(
-                (ISource) listSourceAndFormatter, // ListFormatter MUST be the first source extension
+                new StringSource(formatter),
+                (ISource) listSourceAndFormatter, // ListFormatter MUST be the second source extension
                 new DictionarySource(formatter),
                 new ValueTupleSource(formatter),
                 new SystemTextJsonSource(formatter),


### PR DESCRIPTION
#### Added `StringSource` as another `ISource`

`StringSource` adds the following selector names, which have before been implemented with `ReflectionSource`:
* Length
* ToUpper
* ToUpperInvariant
* ToLower
* ToLowerInvariant
* Trim
* TrimStart
* TrimEnd
* ToCharArray

Additionally, the following selector names are implemented:
* Capitalize
* CapitalizeWords
* FromBase64
* ToBase64

All these selector names may linked. Example with indexed placeholders:
```CSharp
Smart.Format("{0.ToLower.TrimStart.TrimEnd.ToBase64}", " ABCDE ");
// result: "YWJjZGU="
```
This also works for named placeholders.

**Note**: `ReflectionSource` does not evaluate `string`s any more.

The new formatter privates additional funcionality and with with reflection caching, performance is 13% better.

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=5.0.202
  [Host]        : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
Job=.NET Core 5.0  Runtime=.NET Core 5.0
|             Method |     N |        Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 |   Allocated |
|------------------- |------ |------------:|----------:|----------:|----------:|------:|------:|------------:|
| DirectMemberAccess |  1000 |    261.5 us |   5.13 us |   8.71 us |   20.9961 |     - |     - |   171.88 KB |
|     SfStringSource |  1000 |  2,727.5 us |  10.42 us |   9.75 us |    207.03 |     - |     - |  1695.31 KB |
|  SfCacheReflection |  1000 |  3,712.0 us |  67.06 us |  62.73 us |  214.8438 |     - |     - |  1757.81 KB |
|SfNoCacheReflection |  1000 | 13,091.9 us | 129.38 us | 121.02 us |  781.2500 |     - |     - |  6468.75 KB |
|                    |       |             |           |           |           |       |       |             |
| DirectMemberAccess | 10000 |  2,519.2 us |  49.85 us |  53.34 us |  207.0313 |     - |     - |  1718.75 KB |
|     SfStringSource | 10000 | 27,612.5 us |  68.50 us |  64.08 us | 2062.5000 |     - |     - | 16953.13 KB |
|  SfCacheReflection | 10000 | 36,312.6 us | 438.96 us |  389.12us | 2142.8571 |     - |     - | 17578.13 KB |
|SfNoCacheReflection | 10000 |130,049.2 us |1,231.06us |1,027.99us | 7750.0000 |     - |     - | 64687.81 KB |
```