### PR TITLE
Refactored handling of source and formatter extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,25 @@ v3.0.0-alpha.1
 
 ### Current changes merged into the `version/v3.0` branch:
 
+#### Refactored handling of source and formatter extensions ([#179](https://github.com/axuno/SmartFormat/pull/179))
+
+SmartFormatter:
+* `SourceExtensions` is a `IReadOnlyList<ISource>`, and can only be manipulated with the methods below. `ISource` instances will be added only once per type.
+* `FormatterExtensions` is a `IReadOnlyList<IFormatter>`, and can only be manipulated with the methods below. `IFormatter` instances will be added only once per type. Trying to add a formatter with an existing name will throw.
+* Extension can be added and removed using 
+  * `AddExtensions(params ISource[] sourceExtensions)`
+  * `AddExtensions(int position, params ISource[] sourceExtensions)`
+  * `AddExtensions(params IFormatter[] formatterExtensions)`
+  * `AddExtensions(int position, params IFormatter[] formatterExtensions)`
+  * `RemoveSourceExtension<T>()`
+  * `RemoveFormatterExtension<T>()`
+
+Extensions:
+* For performance it is highly recommended to only add such `ISource` and `IFormatter` extensions that are actually required. `Smart.Format(...)` uses all available extensions as the default. Also, use explicit formatter names instead of letting the `SmartFormatter` implicitly find a matching formatter.
+* Neither `ISource` nore `IFormatter` extensions have a CTOR with an argument. This allows for adding extension instances to different `SmartFormatter`s.
+* Any exensions can implement `IInitializer`. If this is implemented, the `SmartFormatter` will call the method `Initialize(SmartFormatter smartFormatter)` of the extension, before adding it to the extension list.
+* The `Source` abstract class implements `IInitializer`. The `SmartFormatter` and the `SmartSettings` are accessible for classes with `Source` as the base class.
+
 #### Added `StringSource` as another `ISource` ([#178](https://github.com/axuno/SmartFormat/pull/178))
 
 `StringSource` adds the following selector names, which have before been implemented with `ReflectionSource`:

--- a/src/SmartFormat.Performance/NullFormatterChooseFormatterTests.cs
+++ b/src/SmartFormat.Performance/NullFormatterChooseFormatterTests.cs
@@ -43,11 +43,11 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
         public void Setup()
         {
             _smartNullFormatter = new SmartFormatter();
-            _smartNullFormatter.AddExtensions(new ISource[] { new DefaultSource(_smartNullFormatter) });
+            _smartNullFormatter.AddExtensions(new ISource[] { new DefaultSource() });
             _smartNullFormatter.AddExtensions(new IFormatter[] { new NullFormatter(), new DefaultFormatter()});
 
             _smartChooseFormatter = new SmartFormatter();
-            _smartChooseFormatter.AddExtensions(new ISource[] { new DefaultSource(_smartChooseFormatter) });
+            _smartChooseFormatter.AddExtensions(new ISource[] { new DefaultSource() });
             _smartChooseFormatter.AddExtensions(new IFormatter[] { new ChooseFormatter(), new DefaultFormatter()});
 
             _nullFormatCache = new FormatCache(_smartNullFormatter.Parser.ParseFormat("{0:isnull:nothing}"));

--- a/src/SmartFormat.Performance/ReflectionVsStringSourceTests.cs
+++ b/src/SmartFormat.Performance/ReflectionVsStringSourceTests.cs
@@ -61,8 +61,8 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
         {
             _reflectionSourceFormatter = new SmartFormatter();
             _reflectionSourceFormatter.AddExtensions(
-                new ReflectionSource(_reflectionSourceFormatter),
-                new DefaultSource(_reflectionSourceFormatter)
+                new ReflectionSource(),
+                new DefaultSource()
             );
             _reflectionSourceFormatter.AddExtensions(
                 new DefaultFormatter()
@@ -70,8 +70,8 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
             _stringSourceFormatter = new SmartFormatter();
             _stringSourceFormatter.AddExtensions(
-                new StringSource(_stringSourceFormatter),
-                new DefaultSource(_stringSourceFormatter)
+                new StringSource(),
+                new DefaultSource()
             );
             _stringSourceFormatter.AddExtensions(
                 new DefaultFormatter()

--- a/src/SmartFormat.Performance/SourcePerformanceTests.cs
+++ b/src/SmartFormat.Performance/SourcePerformanceTests.cs
@@ -73,7 +73,7 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
         {
             _literalFormatter = new SmartFormatter();
             _literalFormatter.AddExtensions(
-                new DefaultSource(_literalFormatter)
+                new DefaultSource()
             );
             _literalFormatter.AddExtensions(
                 new DefaultFormatter()
@@ -81,8 +81,8 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
             _reflectionFormatter = new SmartFormatter();
             _reflectionFormatter.AddExtensions(
-                new ReflectionSource(_reflectionFormatter),
-                new DefaultSource(_reflectionFormatter)
+                new ReflectionSource(),
+                new DefaultSource()
             );
             _reflectionFormatter.AddExtensions(
                 new DefaultFormatter()
@@ -90,8 +90,8 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
             _dictionaryFormatter = new SmartFormatter();
             _dictionaryFormatter.AddExtensions(
-                new DictionarySource(_dictionaryFormatter),
-                new DefaultSource(_dictionaryFormatter)
+                new DictionarySource(),
+                new DefaultSource()
             );
             _dictionaryFormatter.AddExtensions(
                 new DefaultFormatter()
@@ -99,8 +99,8 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
             _jsonFormatter = new SmartFormatter();
             _jsonFormatter.AddExtensions(
-                new SystemTextJsonSource(_jsonFormatter),
-                new DefaultSource(_jsonFormatter)
+                new SystemTextJsonSource(),
+                new DefaultSource()
             );
             _jsonFormatter.AddExtensions(
                 new DefaultFormatter()

--- a/src/SmartFormat.Tests/Core/AlignmentTests.cs
+++ b/src/SmartFormat.Tests/Core/AlignmentTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SmartFormat.Core.Extensions;
 using SmartFormat.Extensions;
 using SmartFormat.Utilities;
 
@@ -16,9 +17,8 @@ namespace SmartFormat.Tests.Core
         private SmartFormatter GetSimpleFormatter()
         {
             var formatter = new SmartFormatter(); 
-            formatter.FormatterExtensions.Add(new DefaultFormatter());
-            formatter.SourceExtensions.Add(new ReflectionSource(formatter));
-            formatter.SourceExtensions.Add(new DefaultSource(formatter));
+            formatter.AddExtensions(new DefaultFormatter());
+            formatter.AddExtensions(new ReflectionSource(), new DefaultSource());
             return formatter;
         }
 
@@ -69,7 +69,7 @@ namespace SmartFormat.Tests.Core
         public void ChooseFormatter_Alignment(int alignment)
         {
             var smart = GetSimpleFormatter();
-            smart.FormatterExtensions.Add(new ChooseFormatter());
+            smart.AddExtensions(new ChooseFormatter());
 
             var data = new {Number = 2};
             var format = $"{{Number,{alignment}:choose(1|2|3):one|two|three}}";
@@ -90,7 +90,7 @@ namespace SmartFormat.Tests.Core
         public void ListFormatter_NestedFormats_Alignment(int alignment)
         {
             var smart = GetSimpleFormatter();
-            smart.FormatterExtensions.Add(new ListFormatter(smart));
+            smart.AddExtensions((IFormatter) new ListFormatter());
 
             var items = new [] { "one", "two", "three" };
             var result = smart.Format($"{{items,{alignment}:list:{{}}|, |, and }}", new { items }); // important: not only "items" as the parameter
@@ -112,7 +112,7 @@ namespace SmartFormat.Tests.Core
         public void ListFormatter_UnnestedFormats_Alignment(string format, string expected)
         {
             var smart = GetSimpleFormatter();
-            smart.FormatterExtensions.Add(new ListFormatter(smart));
+            smart.AddExtensions((IFormatter) new ListFormatter());
 
             var args = new[] {1, 2, 3, 4, 5};
             var result = smart.Format(CultureInfo.InvariantCulture, format, args);

--- a/src/SmartFormat.Tests/Core/FormatCacheTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatCacheTests.cs
@@ -13,9 +13,8 @@ namespace SmartFormat.Tests.Core
         private SmartFormatter GetSimpleFormatter()
         {
             var formatter = new SmartFormatter(); 
-            formatter.FormatterExtensions.Add(new DefaultFormatter());
-            formatter.SourceExtensions.Add(new ReflectionSource(formatter));
-            formatter.SourceExtensions.Add(new DefaultSource(formatter));
+            formatter.AddExtensions(new DefaultFormatter());
+            formatter.AddExtensions(new ReflectionSource(), new DefaultSource());
             return formatter;
         }
 

--- a/src/SmartFormat.Tests/Core/NamedFormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/NamedFormatterTests.cs
@@ -121,7 +121,7 @@ namespace SmartFormat.Tests.Core
         {
             var testFormatter = new SmartFormatter();
             testFormatter.AddExtensions(new TestExtension1(), new TestExtension2(), new DefaultFormatter());
-            testFormatter.AddExtensions(new DefaultSource(testFormatter));
+            testFormatter.AddExtensions(new DefaultSource());
             testFormatter.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             return testFormatter;
         }

--- a/src/SmartFormat.Tests/Core/NestingTests.cs
+++ b/src/SmartFormat.Tests/Core/NestingTests.cs
@@ -32,17 +32,6 @@ namespace SmartFormat.Tests.Core
         }
 
         [Test]
-        [TestCase("{ChildOne.ChildTwo.ChildThree: {Four} {One} }", " 4 1 ")]
-        [TestCase("{ChildOne: {ChildTwo: {ChildThree: {Four} {Three} {Two} {One} } } }", "   4 3 2 1   ")]
-        [TestCase("{ChildOne: {ChildTwo: {ChildThree: {Four} {ChildTwo.Three} {ChildOne.Two} {One} } } }", "   4 3 2 1   ")]
-        [TestCase("{ChildOne: {ChildTwo: {ChildThree: {ChildOne: {ChildTwo: {ChildThree: {Four} } } } } } }", "      4      ")]
-        public void Nesting_can_access_outer_scopes(string format, string expectedOutput)
-        {
-            var actual = Smart.Format(format, data);
-            Assert.AreEqual(expectedOutput, actual);
-        }
-
-        [Test]
         public void Nesting_CurrentScope_propertyName_outrules_OuterScope_propertyName()
         {
             var nestedObject = new

--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -29,9 +29,9 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Enum()
         {
             var formats = new[] {
-                "{0.Friends.0:{FirstName} is a {Gender:man|woman}.}",
-                "{0.Friends.1:{FirstName} is a {Gender:man|woman}.}",
-                "{2.DayOfWeek:Sunday|Monday|Some other day} / {3.DayOfWeek:Sunday|Monday|Some other day}",
+                "{0.Friends.0:{FirstName} is a {Gender:cond:man|woman}.}",
+                "{0.Friends.1:{FirstName} is a {Gender:cond:man|woman}.}",
+                "{2.DayOfWeek:cond:Sunday|Monday|Some other day} / {3.DayOfWeek:cond:Sunday|Monday|Some other day}",
             };
             var expected = new[] {
                 "Jim is a man.",
@@ -47,8 +47,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Bool()
         {
             var formats = new[] {
-                "{0:Yes|No}",
-                "{1:Yes|No}",
+                "{0:cond:Yes|No}",
+                "{1:cond:Yes|No}",
             };
             var expected = new[] {
                 "No",
@@ -63,8 +63,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Dates()
         {
             var formats = new[] {
-                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
-                "{0:Past|Present|Future} {1:Past|Present|Future} {2:Past|Present|Future}",
+                "{0:cond:Past|Future} {1:cond:Past|Future} {2:cond:Past|Future}",
+                "{0:cond:Past|Present|Future} {1:cond:Past|Present|Future} {2:cond:Past|Present|Future}",
             };
             var expected = new[] {
                 "Past Past Future",
@@ -79,8 +79,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_DateTimeOffset_Dates()
         {
             var formats = new[] {
-                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
-                "{0:Past|Present|Future} {1:Past|Present|Future} {2:Past|Present|Future}",
+                "{0:cond:Past|Future} {1:cond:Past|Future} {2:cond:Past|Future}",
+                "{0:cond:Past|Present|Future} {1:cond:Past|Present|Future} {2:cond:Past|Present|Future}",
             };
             var expected = new[] {
                 "Past Past Future",
@@ -97,8 +97,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_TimeSpan()
         {
             var formats = new[] {
-                "{0:Past|Future} {1:Past|Future} {2:Past|Future}",
-                "{0:Past|Zero|Future} {1:Past|Zero|Future} {2:Past|Zero|Future}",
+                "{0:cond:Past|Future} {1:cond:Past|Future} {2:cond:Past|Future}",
+                "{0:cond:Past|Zero|Future} {1:cond:Past|Zero|Future} {2:cond:Past|Zero|Future}",
             };
             var expected = new[] {
                 "Past Past Future",

--- a/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/DictionaryFormatterTests.cs
@@ -55,7 +55,7 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Dictionary()
         {
             var formatter = Smart.CreateDefaultSmartFormat();
-            formatter.AddExtensions(new DictionarySource(formatter));
+            formatter.AddExtensions(new DictionarySource());
 
             var formats = new[]
             {
@@ -75,7 +75,7 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Dynamic()
         {
             var formatter = Smart.CreateDefaultSmartFormat();
-            formatter.AddExtensions(new DictionarySource(formatter));
+            formatter.AddExtensions(new DictionarySource());
 
             var formats = new[]
             {
@@ -96,7 +96,7 @@ namespace SmartFormat.Tests.Extensions
         {
             var formatter = Smart.CreateDefaultSmartFormat();
             formatter.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
-            formatter.AddExtensions(new DictionarySource(formatter));
+            formatter.AddExtensions(new DictionarySource());
 
             var formats = new string[]
             {
@@ -149,7 +149,7 @@ namespace SmartFormat.Tests.Extensions
                            $"Name: {addr.Person.FirstName} {addr.Person.LastName}";
 
             var smart = new SmartFormatter();
-            smart.AddExtensions(new ISource[] { new DefaultSource(smart), new DictionarySource(smart) });
+            smart.AddExtensions(new ISource[] { new DefaultSource(), new DictionarySource() });
             smart.AddExtensions(new IFormatter[] {new DefaultFormatter()});
             
             var result = smart.Format(format, addrDict);

--- a/src/SmartFormat.Tests/Extensions/IsMatchFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/IsMatchFormatterTests.cs
@@ -20,7 +20,7 @@ namespace SmartFormat.Tests.Extensions
         public IsMatchFormatterTests()
         {
             _formatter = Smart.CreateDefaultSmartFormat();
-            _formatter.FormatterExtensions.Add(new IsMatchFormatter {RegexOptions = RegexOptions.CultureInvariant});
+            _formatter.AddExtensions(new IsMatchFormatter {RegexOptions = RegexOptions.CultureInvariant});
             _formatter.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
         }
         

--- a/src/SmartFormat.Tests/Extensions/NewtonsoftJsonSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/NewtonsoftJsonSourceTests.cs
@@ -54,8 +54,8 @@ namespace SmartFormat.Tests.Extensions
             var smart = new SmartFormatter();
             // NewtonsoftJsonSource MUST be registered before ReflectionSource (which is not required here)
             // We also need the ListFormatter to process arrays
-            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new NewtonsoftJsonSource(smart) });
-            smart.AddExtensions(new IFormatter[] {new ListFormatter(smart), new DefaultFormatter()});
+            smart.AddExtensions(new ISource[] { new ListFormatter(), new DefaultSource(), new NewtonsoftJsonSource() });
+            smart.AddExtensions(new IFormatter[] {new ListFormatter(), new DefaultFormatter()});
             return smart;
         }
 
@@ -72,7 +72,7 @@ namespace SmartFormat.Tests.Extensions
         {
             var smart = new SmartFormatter();
             // removed DefaultSource in order to evaluate JValue
-            smart.AddExtensions(new ISource[] { new NewtonsoftJsonSource(smart) });
+            smart.AddExtensions(new ISource[] { new NewtonsoftJsonSource() });
             smart.AddExtensions(new IFormatter[] {new DefaultFormatter()});
             var result = smart.Format("{0}", new JValue('v'));
             Assert.AreEqual("v", result);

--- a/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/NullFormatterTests.cs
@@ -15,8 +15,8 @@ namespace SmartFormat.Tests.Extensions
         private SmartFormatter GetFormatter()
         {
             var smart = new SmartFormatter();
-            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new ReflectionSource(smart) });
-            smart.AddExtensions(new IFormatter[] { new NullFormatter(), new ListFormatter(smart), new DefaultFormatter()});
+            smart.AddExtensions(new ISource[] { new ListFormatter(), new DefaultSource(), new ReflectionSource() });
+            smart.AddExtensions(new IFormatter[] { new NullFormatter(), new ListFormatter(), new DefaultFormatter()});
             return smart;
         }
 
@@ -68,7 +68,7 @@ namespace SmartFormat.Tests.Extensions
         public void Combine_NullFormatter_With_Other_Formatter(object value, string expected)
         {
             var smart = new SmartFormatter();
-            smart.AddExtensions(new ISource[] { new DefaultSource(smart) });
+            smart.AddExtensions(new ISource[] { new DefaultSource() });
             smart.AddExtensions(new IFormatter[] { new NullFormatter(), new DefaultFormatter()});
             
             // NullFormatter will output only, if value is null

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -28,7 +28,7 @@ namespace SmartFormat.Tests.Extensions
         {
             TestAllResults(
                 new CultureInfo("en-US"),
-                "There {0:is|are} {0} {0:item|items} remaining",
+                "There {0:plural:is|are} {0} {0:plural:item|items} remaining",
                 new ExpectedResults {
                     {  -1, "There are -1 items remaining"},
                     {   0, "There are 0 items remaining"},
@@ -45,7 +45,7 @@ namespace SmartFormat.Tests.Extensions
         {
             TestAllResults(
                 new CultureInfo("en-US"),
-                "There {0:is|are} {0} {0:item|items} remaining",
+                "There {0:plural:is|are} {0} {0:plural:item|items} remaining",
                 new ExpectedResults {
                     {  -1, "There are -1 items remaining"},
                     {   0, "There are 0 items remaining"},
@@ -108,7 +108,7 @@ namespace SmartFormat.Tests.Extensions
 
             TestAllResults(
                 new CultureInfo("tr"),
-                "Seçili {0:nesneyi|nesneleri} silmek istiyor musunuz?",
+                "Seçili {0:plural:nesneyi|nesneleri} silmek istiyor musunuz?",
                 new ExpectedResults {
                     {  -1, "Seçili nesneleri silmek istiyor musunuz?"},
                     {   0, "Seçili nesneleri silmek istiyor musunuz?"},
@@ -125,7 +125,7 @@ namespace SmartFormat.Tests.Extensions
         {
             TestAllResults(
                 new CultureInfo("ru-RU"),
-                "Я купил {0} {0:банан|банана|бананов}.",
+                "Я купил {0} {0:plural:банан|банана|бананов}.",
                 new ExpectedResults {
                     {   0, "Я купил 0 бананов."},
                     {   1, "Я купил 1 банан."},
@@ -147,7 +147,7 @@ namespace SmartFormat.Tests.Extensions
         {
             TestAllResults(
                 new CultureInfo("pl"),
-                "{0} {0:miesiąc|miesiące|miesięcy} temu",
+                "{0} {0:plural:miesiąc|miesiące|miesięcy} temu",
                 new ExpectedResults {
                     {   0, "0 miesięcy temu"},
                     {   1, "1 miesiąc temu"},

--- a/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
@@ -82,8 +82,8 @@ namespace SmartFormat.Tests.Extensions
             //var expected = "Zero zero zero ZERO";
 
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new ReflectionSource(smart), new DefaultSource(smart)});
-            smart.FormatterExtensions.Add(new DefaultFormatter());
+            smart.AddExtensions(new ReflectionSource(), new DefaultSource());
+            smart.AddExtensions(new DefaultFormatter());
 
             var args = GetArgs();
             Assert.That(() => smart.Format(format, args), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("ToLower"));
@@ -96,8 +96,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Methods_CaseInsensitive()
         {
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new ReflectionSource(smart)});
-            smart.FormatterExtensions.Add(new DefaultFormatter());
+            smart.AddExtensions(new ReflectionSource());
+            smart.AddExtensions(new DefaultFormatter());
             smart.Settings.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
 
             var format = "{0} {0.ToLower} {toloWer} {touPPer}";
@@ -110,8 +110,8 @@ namespace SmartFormat.Tests.Extensions
         public void Void_Methods_Should_Just_Be_Ignored()
         {
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new ReflectionSource(smart), new DefaultSource(smart)});
-            smart.FormatterExtensions.Add(new DefaultFormatter());
+            smart.AddExtensions(new ReflectionSource(), new DefaultSource());
+            smart.AddExtensions(new DefaultFormatter());
             Assert.That(() => smart.Format("{0.Clear}", smart.SourceExtensions), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("Clear"));
         }
 
@@ -119,8 +119,8 @@ namespace SmartFormat.Tests.Extensions
         public void Methods_With_Parameter_Should_Just_Be_Ignored()
         {
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new ReflectionSource(smart), new DefaultSource(smart)});
-            smart.FormatterExtensions.Add(new DefaultFormatter());
+            smart.AddExtensions(new ReflectionSource(), new DefaultSource());
+            smart.AddExtensions(new DefaultFormatter());
             Assert.That(() => smart.Format("{0.Add}", smart.SourceExtensions), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("Add"));
         }
 
@@ -128,8 +128,8 @@ namespace SmartFormat.Tests.Extensions
         public void Properties_With_No_Getter_Should_Just_Be_Ignored()
         {
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new ReflectionSource(smart), new DefaultSource(smart)});
-            smart.FormatterExtensions.Add(new DefaultFormatter());
+            smart.AddExtensions(new ReflectionSource(), new DefaultSource());
+            smart.AddExtensions(new DefaultFormatter());
             Assert.That(() => smart.Format("{Misc.OnlySetterProperty}", new { Misc = new MiscObject() }), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("OnlySetterProperty"));
         }
         
@@ -224,7 +224,7 @@ namespace SmartFormat.Tests.Extensions
         public void Nullable_Property_Should_Return_Null()
         {
             var smart = new SmartFormatter();
-            smart.AddExtensions(new ISource[] { new DefaultSource(smart), new ReflectionSource(smart) });
+            smart.AddExtensions(new ISource[] { new DefaultSource(), new ReflectionSource() });
             smart.AddExtensions(new IFormatter[] {new DefaultFormatter()});
             var data = new {Person = new Person()};
 

--- a/src/SmartFormat.Tests/Extensions/SmartExtensionsTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SmartExtensionsTests.cs
@@ -27,21 +27,23 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Test_AppendLine()
         {
-            var formats = new string[] {
-                "{0}",
-                "{1}",
-                "{2}",
-                "{3}",
-                "{4}",
-                "{5}",
+            var formats = new[]
+            {
+                "{0:time:}",
+                "{1:time:}",
+                "{2:time:}",
+                "{3:time:}",
+                "{4:time:}",
+                "{5:time:}"
             };
-            var expected = new string[] {
-                "less than 1 second"+Environment.NewLine,
-                "1 day 1 hour 1 minute 1 second"+Environment.NewLine,
-                "2 hours 2 seconds"+Environment.NewLine,
-                "3 days 3 seconds"+Environment.NewLine,
-                "less than 1 second"+Environment.NewLine,
-                "5 days"+Environment.NewLine,
+            var expected = new[]
+            {
+                "less than 1 second" + Environment.NewLine,
+                "1 day 1 hour 1 minute 1 second" + Environment.NewLine,
+                "2 hours 2 seconds" + Environment.NewLine,
+                "3 days 3 seconds" + Environment.NewLine,
+                "less than 1 second" + Environment.NewLine,
+                "5 days" + Environment.NewLine
             };
             var args = GetArgs();
 
@@ -51,18 +53,18 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Test_Append()
         {
-            var formats = new string[] {
-                "{0:noless}",
-                "{1:hours}",
-                "{1:hours minutes}",
-                "{2:days milliseconds}",
-                "{2:days milliseconds auto}",
-                "{2:days milliseconds short}",
-                "{2:days milliseconds fill}",
-                "{2:days milliseconds full}",
-                "{3:abbr}",
+            var formats = new [] {
+                "{0:time:noless}",
+                "{1:time:hours}",
+                "{1:time:hours minutes}",
+                "{2:time:days milliseconds}",
+                "{2:time:days milliseconds auto}",
+                "{2:time:days milliseconds short}",
+                "{2:time:days milliseconds fill}",
+                "{2:time:days milliseconds full}",
+                "{3:time:abbr}",
             };
-            var expected = new string[] {
+            var expected = new [] {
                 "0 seconds",
                 "25 hours",
                 "25 hours 1 minute",

--- a/src/SmartFormat.Tests/Extensions/StringSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/StringSourceTests.cs
@@ -18,8 +18,8 @@ namespace SmartFormat.Tests.Extensions
         private SmartFormatter GetSimpleFormatter()
         {
             var smart = new SmartFormatter();
-            smart.SourceExtensions.AddRange(new ISource[]{new StringSource(smart), new DefaultSource(smart)});
-            smart.FormatterExtensions.AddRange(new IFormatter[] {new DefaultFormatter()});
+            smart.AddExtensions(new StringSource(), new DefaultSource());
+            smart.AddExtensions(new DefaultFormatter());
             return smart;
         }
 
@@ -93,8 +93,9 @@ namespace SmartFormat.Tests.Extensions
         public void String_ToCharArray_Should_Be_Formattable_As_List(string arg, string expected)
         {
             var smart = GetSimpleFormatter();
-            smart.SourceExtensions.Add(new ListFormatter(smart));
-            smart.FormatterExtensions.Add(new ListFormatter(smart));
+            var listSourceAndFormatter = new ListFormatter();
+            smart.AddExtensions((ISource) listSourceAndFormatter);
+            smart.AddExtensions((IFormatter) listSourceAndFormatter);
            
             Assert.That(smart.Format("{0.ToCharArray:list:{}|, |, and }", arg), Is.EqualTo(expected));
         }

--- a/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SubStringFormatterTests.cs
@@ -20,7 +20,7 @@ namespace SmartFormat.Tests.Extensions
 
             if (_smart.FormatterExtensions.FirstOrDefault(fmt => fmt.Names.Contains("substr")) == null)
             {
-                _smart.FormatterExtensions.Add(new SubStringFormatter());
+                _smart.AddExtensions(new SubStringFormatter());
             }
 
             _people = new List<object>

--- a/src/SmartFormat.Tests/Extensions/SystemTextJsonSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SystemTextJsonSourceTests.cs
@@ -53,8 +53,8 @@ namespace SmartFormat.Tests.Extensions
             var smart = new SmartFormatter();
             // SystemTextJsonSource MUST be registered before ReflectionSource (which is not required here)
             // We also need the ListFormatter to process arrays
-            smart.AddExtensions(new ISource[] { new ListFormatter(smart), new DefaultSource(smart), new SystemTextJsonSource(smart) });
-            smart.AddExtensions(new IFormatter[] {new ListFormatter(smart), new DefaultFormatter()});
+            smart.AddExtensions(new ISource[] { new ListFormatter(), new DefaultSource(), new SystemTextJsonSource() });
+            smart.AddExtensions(new IFormatter[] {new ListFormatter(), new DefaultFormatter()});
             return smart;
         }
 

--- a/src/SmartFormat.Tests/Extensions/TimeFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/TimeFormatterTests.cs
@@ -23,7 +23,7 @@ namespace SmartFormat.Tests.Extensions
             if (timeFormatter == null)
             {
                 timeFormatter = new TimeFormatter("en");
-                _smart.FormatterExtensions.Add(timeFormatter);
+                _smart.AddExtensions(timeFormatter);
             }
         }
 
@@ -58,12 +58,12 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Defaults()
         {
             var formats = new string[] {
-                "{0}",
-                "{1}",
-                "{2}",
-                "{3}",
-                "{4}",
-                "{5}",
+                "{0:time:}",
+                "{1:time:}",
+                "{2:time:}",
+                "{3:time:}",
+                "{4:time:}",
+                "{5:time:}",
             };
             var expected = new string[] {
                 "less than 1 second",
@@ -81,15 +81,15 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Options()
         {
             var formats = new string[] {
-                "{0:noless}",
-                "{1:hours}",
-                "{1:hours minutes}",
-                "{2:days milliseconds}",
-                "{2:days milliseconds auto}",
-                "{2:days milliseconds short}",
-                "{2:days milliseconds fill}",
-                "{2:days milliseconds full}",
-                "{3:abbr}",
+                "{0:time:noless}",
+                "{1:time:hours}",
+                "{1:time:hours minutes}",
+                "{2:time:days milliseconds}",
+                "{2:time:days milliseconds auto}",
+                "{2:time:days milliseconds short}",
+                "{2:time:days milliseconds fill}",
+                "{2:time:days milliseconds full}",
+                "{3:time:abbr}",
             };
             var expected = new string[] {
                 "0 seconds",

--- a/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ValueTupleTests.cs
@@ -110,7 +110,7 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Not_Invoked_With_FormattingInfo()
         {
-            Assert.IsFalse(new ValueTupleSource(new SmartFormatter()).TryEvaluateSelector(new PureSelectorInfo()));
+            Assert.IsFalse(new ValueTupleSource().TryEvaluateSelector(new PureSelectorInfo()));
         }
 
         private class PureSelectorInfo : ISelectorInfo

--- a/src/SmartFormat.Tests/Extensions/XmlSourceTest.cs
+++ b/src/SmartFormat.Tests/Extensions/XmlSourceTest.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
+using SmartFormat.Extensions;
 
 namespace SmartFormat.Tests.Extensions
 {
@@ -44,7 +45,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = Smart.Format("Mr. {FirstName} {LastName}", xmlEl);
+            var res = Smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe Doe", res);
         }
@@ -55,7 +56,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = Smart.Format("Mr. {FirstName.0}", xmlEl);
+            var res = Smart.Format("Mr. {FirstName.0:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe", res);
         }
@@ -66,7 +67,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(OneLevelXmlWithNameSpaces);
             // act
-            var res = Smart.Format("Mr. {FirstName} {LastName}", xmlEl);
+            var res = Smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe Doe", res);
         }
@@ -79,7 +80,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = sf.Format("Mr. \\{{LastName}\\}", xmlEl);
+            var res = sf.Format("Mr. \\{{LastName:xml:}\\}", xmlEl);
             // assert
             Assert.AreEqual("Mr. {Doe}", res);
         }
@@ -90,7 +91,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("Mr. {FirstName.1} {LastName}", xmlEl);
+            var res = Smart.Format("Mr. {FirstName.1:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Jack Doe", res);
         }
@@ -101,7 +102,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("Mr. {FirstName}", xmlEl);
+            var res = Smart.Format("Mr. {FirstName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe", res);
         }
@@ -112,7 +113,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("There{FirstName.Count: is {} Doe | are {} Does}", xmlEl);
+            var res = Smart.Format("There{FirstName.Count:cond: is {} Doe | are {} Does}", xmlEl);
             // assert
             Assert.AreEqual("There are 3 Does", res);
         }
@@ -123,7 +124,7 @@ namespace SmartFormat.Tests.Extensions
             // arrange
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("There are{FirstName: {}|,|, and} Doe", xmlEl);
+            var res = Smart.Format("There are{FirstName:list: {}|,|, and} Doe", xmlEl);
             // assert
             Assert.AreEqual("There are Joe, Jack, and Jim Doe", res);
         }

--- a/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
+++ b/src/SmartFormat.Tests/Utilities/CustomFormatProviderTests.cs
@@ -14,8 +14,8 @@ namespace SmartFormat.Tests.Utilities
         private SmartFormatter GetSimpleFormatter()
         {
             var formatter = new SmartFormatter(); 
-            formatter.FormatterExtensions.Add(new DefaultFormatter());
-            formatter.SourceExtensions.Add(new DefaultSource(formatter));
+            formatter.AddExtensions(new DefaultFormatter());
+            formatter.AddExtensions(new DefaultSource());
             return formatter;
         }
 

--- a/src/SmartFormat/Core/Extensions/IFormatter.cs
+++ b/src/SmartFormat/Core/Extensions/IFormatter.cs
@@ -3,6 +3,9 @@
 // Licensed under the MIT license.
 //
 
+using System;
+using SmartFormat.Core.Settings;
+
 namespace SmartFormat.Core.Extensions
 {
     /// <summary> Converts an object to a string. </summary>
@@ -12,7 +15,7 @@ namespace SmartFormat.Core.Extensions
         /// An extension can be explicitly called by using any of its names.
         /// Any extensions with empty names will be called implicitly (when no named formatter is specified).
         /// For example, "{0:default:N2}" or "{0:d:N2}" will explicitly call the "default" extension.
-        /// "{0:N2}" will implicitly call the "default" extension (and other extensions, too).
+        /// "{0:N2}" will implicitly call the "default" extension, and other extensions containing <see cref="string.Empty"/> as a name, too.
         /// </summary>
         string[] Names { get; set; }
 

--- a/src/SmartFormat/Core/Extensions/IInitializer.cs
+++ b/src/SmartFormat/Core/Extensions/IInitializer.cs
@@ -1,0 +1,22 @@
+﻿//
+// Copyright (C) axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.
+// Licensed under the MIT license.
+//
+
+using SmartFormat.Core.Parsing;
+
+namespace SmartFormat.Core.Extensions
+{
+    /// <summary>
+    /// Initializes an <see cref="ISource"/> or <see cref="IFormatter"/>.
+    /// </summary>
+    public interface IInitializer
+    {
+        /// <summary>
+        /// Initializes an <see cref="ISource"/> or <see cref="IFormatter"/>.
+        /// The method gets called when adding an extension to a <see cref="SmartFormatter"/> instance.
+        /// </summary>
+        /// <param name="smartFormatter"></param>
+        void Initialize(SmartFormatter smartFormatter);
+    }
+}

--- a/src/SmartFormat/Core/Extensions/Source.cs
+++ b/src/SmartFormat/Core/Extensions/Source.cs
@@ -8,41 +8,36 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using SmartFormat.Core.Parsing;
+using SmartFormat.Core.Settings;
 
 namespace SmartFormat.Core.Extensions
 {
     /// <summary>
     /// The base class for <see cref="ISource"/> extension classes.
     /// </summary>
-    public abstract class Source : ISource
+    public abstract class Source : ISource, IInitializer
     {
         /// <summary>
         /// The instance of the current <see cref="SmartFormatter"/>.
         /// </summary>
-        protected readonly SmartFormatter _formatter;
+        protected SmartFormatter? _formatter;
 
         /// <summary>
-        /// The operator character used to indicate <c>nullable</c>.
+        /// The instance of the current <see cref="SmartSettings"/>.
         /// </summary>
-        protected readonly char _nullableOperator;
-
-        /// <summary>
-        /// The general operator character used to separate <see cref="Selector"/>s.
-        /// </summary>
-        protected readonly char _selectorOperator;
-
-        /// <inheritdoc cref="ISource" />
-        protected Source(SmartFormatter formatter)
-        {
-            _formatter = formatter;
-            _nullableOperator = formatter.Settings.Parser.NullableOperator;
-            _selectorOperator = formatter.Settings.Parser.SelectorOperator;
-        }
+        protected SmartSettings? _smartSettings;
 
         /// <inheritdoc />
         public virtual bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
             return false;
+        }
+
+        /// <inheritdoc />
+        public virtual void Initialize(SmartFormatter formatter)
+        {
+            _formatter = formatter;
+            _smartSettings = formatter.Settings;
         }
 
         /// <summary>
@@ -57,9 +52,9 @@ namespace SmartFormat.Core.Extensions
         /// </remarks>
         protected virtual bool HasNullableOperator(ISelectorInfo selectorInfo)
         {
-            return selectorInfo.Placeholder != null &&
+            return _smartSettings != null && selectorInfo.Placeholder != null &&
                    selectorInfo.Placeholder.Selectors.Any(s =>
-                       s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _nullableOperator);
+                       s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator);
         }
     }
 }

--- a/src/SmartFormat/Core/Formatting/FormattingInfo.cs
+++ b/src/SmartFormat/Core/Formatting/FormattingInfo.cs
@@ -80,7 +80,7 @@ namespace SmartFormat.Core.Formatting
         /// <summary>
         /// Gets the <see cref="Placeholder"/>.
         /// </summary>
-        public Placeholder? Placeholder { get; }
+        public Placeholder? Placeholder { get; internal set; }
 
         /// <summary>
         /// Gets the <see cref="Alignment"/> of the current <see cref="Placeholder"/>,

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -5,6 +5,7 @@
 
 using System;
 using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Settings;
 
 namespace SmartFormat.Extensions
 {
@@ -25,7 +26,6 @@ namespace SmartFormat.Extensions
         {
             var format = formattingInfo.Format;
             var current = formattingInfo.CurrentValue;
-
             // If the format has nested placeholders, we process those first
             // instead of formatting the item.
             if (format is {HasNested: true})

--- a/src/SmartFormat/Extensions/DefaultSource.cs
+++ b/src/SmartFormat/Extensions/DefaultSource.cs
@@ -18,17 +18,6 @@ namespace SmartFormat.Extensions
     /// </example>
     public class DefaultSource : Source
     {
-        private readonly SmartSettings _settings;
-
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public DefaultSource(SmartFormatter formatter) : base(formatter)
-        {
-            _settings = formatter.Settings;
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Extensions/DictionarySource.cs
+++ b/src/SmartFormat/Extensions/DictionarySource.cs
@@ -17,14 +17,6 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class DictionarySource : Source
     {
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public DictionarySource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />>
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -38,21 +38,12 @@ namespace SmartFormat.Extensions
     /// <remarks>
     /// The <see cref="ListFormatter"/> PluralLocalizationExtension and ConditionalExtension
     /// </remarks>
-    public class ListFormatter : IFormatter, ISource
+    public class ListFormatter : IFormatter, ISource, IInitializer
     {
-        private readonly SmartSettings _smartSettings;
+        private SmartSettings _smartSettings = new();
 
         ///<inheritdoc />
         public string[] Names { get; set; } = {"list", "l", string.Empty};
-
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public ListFormatter(SmartFormatter formatter)
-        {
-            _smartSettings = formatter.Settings;
-        }
 
         /// <summary>
         /// This allows an integer to be used as a selector to index an array (or list).
@@ -257,6 +248,12 @@ namespace SmartFormat.Extensions
             return formattingInfo.Placeholder != null &&
                    formattingInfo.Placeholder.Selectors.Any(s =>
                        s.OperatorLength > 0 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator);
+        }
+
+        ///<inheritdoc />
+        public void Initialize(SmartFormatter smartFormatter)
+        {
+            _smartSettings = smartFormatter.Settings;
         }
     }
 }

--- a/src/SmartFormat/Extensions/NewtonsoftJsonSource.cs
+++ b/src/SmartFormat/Extensions/NewtonsoftJsonSource.cs
@@ -16,14 +16,6 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class NewtonsoftJsonSource : Source
     {
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public NewtonsoftJsonSource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Extensions/ReflectionSource.cs
+++ b/src/SmartFormat/Extensions/ReflectionSource.cs
@@ -22,14 +22,6 @@ namespace SmartFormat.Extensions
 
         private readonly Dictionary<(Type, string?), (FieldInfo? field, MethodInfo? method)> _typeCache = new();
 
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public ReflectionSource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Extensions/SourceEqualityComparer.cs
+++ b/src/SmartFormat/Extensions/SourceEqualityComparer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SmartFormat.Core.Extensions;
+
+namespace SmartFormat.Extensions
+{
+    internal class SourceTypeEqualityComparer : IEqualityComparer<ISource>
+    {
+        public bool Equals(ISource x, ISource y)
+        {
+            return x.GetType() == y.GetType();
+        }
+
+        public int GetHashCode(ISource obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/src/SmartFormat/Extensions/StringSource.cs
+++ b/src/SmartFormat/Extensions/StringSource.cs
@@ -27,13 +27,9 @@ namespace SmartFormat.Extensions
         /// <summary>
         /// CTOR.
         /// </summary>
-        /// <param name="formatter"></param>
-        public StringSource(SmartFormatter formatter) : base(formatter)
+        public StringSource() : base()
         {
-            var comparer = new SmartSettings {CaseSensitivity = CaseSensitivityType.CaseInsensitive}
-                .GetCaseSensitivityComparer();
-            SelectorMethods =  new Dictionary<string, Func<ISelectorInfo, string, bool>>(comparer);
-            AddMethods();
+            SelectorMethods =  new Dictionary<string, Func<ISelectorInfo, string, bool>>();
         }
 
         /// <summary>
@@ -42,10 +38,23 @@ namespace SmartFormat.Extensions
         protected Dictionary<string, Func<ISelectorInfo, string, bool>> SelectorMethods
         {
             get;
+            private set;
+        }
+
+        /// <inheritdoc />
+        public override void Initialize(SmartFormatter formatter)
+        {
+            base.Initialize(formatter);
+            var comparer = new SmartSettings {CaseSensitivity = CaseSensitivityType.CaseInsensitive}
+                .GetCaseSensitivityComparer();
+            SelectorMethods =  new Dictionary<string, Func<ISelectorInfo, string, bool>>(comparer);
+            AddMethods();
         }
 
         private void AddMethods()
         {
+            if (SelectorMethods is null) return;
+
             // built-in string methods
             SelectorMethods.Add(nameof(Length), Length);
             SelectorMethods.Add(nameof(ToUpper), ToUpper);

--- a/src/SmartFormat/Extensions/SystemTextJsonSource.cs
+++ b/src/SmartFormat/Extensions/SystemTextJsonSource.cs
@@ -17,14 +17,6 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class SystemTextJsonSource : Source
     {
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public SystemTextJsonSource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Extensions/TimeFormatter.cs
+++ b/src/SmartFormat/Extensions/TimeFormatter.cs
@@ -16,7 +16,7 @@ namespace SmartFormat.Extensions
     public class TimeFormatter : IFormatter
     {
         ///<inheritdoc />
-        public string[] Names { get; set; } = {"timespan", "time", "t", string.Empty};
+        public string[] Names { get; set; } = {"timespan", "time", string.Empty};
 
         #region Constructors
 

--- a/src/SmartFormat/Extensions/ValueTupleSource.cs
+++ b/src/SmartFormat/Extensions/ValueTupleSource.cs
@@ -20,14 +20,6 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class ValueTupleSource : Source
     {
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public ValueTupleSource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
@@ -39,7 +31,7 @@ namespace SmartFormat.Extensions
             {
                 formattingInfo.CurrentValue = obj;
 
-                foreach (var sourceExtension in _formatter.SourceExtensions)
+                foreach (var sourceExtension in selectorInfo.FormatDetails.Formatter.SourceExtensions)
                 {
                     var handled = sourceExtension.TryEvaluateSelector(formattingInfo);
                     if (handled)

--- a/src/SmartFormat/Extensions/XmlSource.cs
+++ b/src/SmartFormat/Extensions/XmlSource.cs
@@ -15,14 +15,6 @@ namespace SmartFormat.Extensions
     /// </summary>
     public class XmlSource : Source
     {
-        /// <summary>
-        /// CTOR.
-        /// </summary>
-        /// <param name="formatter"></param>
-        public XmlSource(SmartFormatter formatter) : base(formatter)
-        {
-        }
-
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -108,21 +108,21 @@ namespace SmartFormat
             // Note, the order is important; the extensions
             // will be executed in this order:
 
-            var listSourceAndFormatter = new ListFormatter(formatter);
+            var listSourceAndFormatter = new ListFormatter();
 
             // sources for specific types must be in the list before ReflectionSource
             formatter.AddExtensions(
-                new StringSource(formatter),
+                new StringSource(),
                 (ISource) listSourceAndFormatter, // ListFormatter MUST be the second source extension
-                new DictionarySource(formatter),
-                new ValueTupleSource(formatter),
-                new SystemTextJsonSource(formatter),
-                new NewtonsoftJsonSource(formatter),
-                new XmlSource(formatter),
-                new ReflectionSource(formatter),
+                new DictionarySource(),
+                new ValueTupleSource(),
+                new SystemTextJsonSource(),
+                new NewtonsoftJsonSource(),
+                new XmlSource(),
+                new ReflectionSource(),
 
                 // The DefaultSource reproduces the string.Format behavior:
-                new DefaultSource(formatter)
+                new DefaultSource()
             );
             formatter.AddExtensions(
                 (IFormatter) listSourceAndFormatter,


### PR DESCRIPTION
See the change log for a list of all changes to `SmartFormatter`, and `ISource` and `IFormatter` extensions.