### PR TITLE
Removed all shared or default formatters from tests

### DIFF
--- a/src/SmartFormat.Tests/Core/LiteralTextTests.cs
+++ b/src/SmartFormat.Tests/Core/LiteralTextTests.cs
@@ -69,12 +69,13 @@ namespace SmartFormat.Tests.Core
         [Test]
         public void ConvertCharacterLiteralsToUnicodeWithListFormatter()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.Parser.ConvertCharacterStringLiterals = true;
             // a useful practical test case: separate members of a list by a new line
             var items = new[] { "one", "two", "three" };
             // Note the @ before the format string will switch off conversion of \n by the compiler
-            Smart.Default.Settings.Parser.ConvertCharacterStringLiterals = true;
-            var result = Smart.Default.Format(@"{0:list:{}|\n|\nand }", new object[] { items });
-            Smart.Default.Settings.Parser.ConvertCharacterStringLiterals = false;
+            var result = smart.Format(@"{0:list:{}|\n|\nand }", new object[] { items });
+            
             Assert.AreEqual("one\ntwo\nand three", result);
         }
     }

--- a/src/SmartFormat.Tests/Core/NamedFormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/NamedFormatterTests.cs
@@ -36,7 +36,8 @@ namespace SmartFormat.Tests.Core
 
         public void Invoke_extensions_by_name_or_shortname(string format, object arg0, string expectedResult)
         {
-            var actualResult = Smart.Format(new CultureInfo("en-US"), format, arg0); // must be culture with decimal point
+            var smart = Smart.CreateDefaultSmartFormat();
+            var actualResult = smart.Format(new CultureInfo("en-US"), format, arg0); // must be culture with decimal point
             Assert.AreEqual(expectedResult, actualResult);
         }
 
@@ -47,10 +48,11 @@ namespace SmartFormat.Tests.Core
         [TestCase(false, "no (possibly)")]
         public void Conditional_Formatter_With_Parenthesis(bool value, string expected)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             // explicit conditional formatter
-            Assert.AreEqual(expected, Smart.Format("{value:conditional:yes (probably)|no (possibly)}", new { value }));
+            Assert.AreEqual(expected, smart.Format("{value:conditional:yes (probably)|no (possibly)}", new { value }));
             // implicit
-            Assert.AreEqual(expected, Smart.Format("{value:yes (probably)|no (possibly)}", new { value }));
+            Assert.AreEqual(expected, smart.Format("{value:yes (probably)|no (possibly)}", new { value }));
         }
 
         #region: Custom Extensions :

--- a/src/SmartFormat.Tests/Core/NestingTests.cs
+++ b/src/SmartFormat.Tests/Core/NestingTests.cs
@@ -27,13 +27,15 @@ namespace SmartFormat.Tests.Core
         [TestCase("{ChildOne.ChildTwo.ChildThree: {Four} {0.ChildOne: {Two} {0.One} } }", " 4  2 1  ")]
         public void Nesting_can_access_root_via_number(string format, string expectedOutput)
         {
-            var actual = Smart.Format(format, data);
+            var smart = Smart.CreateDefaultSmartFormat();
+            var actual = smart.Format(format, data);
             Assert.AreEqual(expectedOutput, actual);
         }
 
         [Test]
         public void Nesting_CurrentScope_propertyName_outrules_OuterScope_propertyName()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var nestedObject = new
             {
                 IdenticalName = "Name from parent", 
@@ -42,10 +44,10 @@ namespace SmartFormat.Tests.Core
             };
 
             // Access to outer scope, if no current scope variable is found
-            Assert.AreEqual(string.Format($"{nestedObject.ParentValue} - {nestedObject.Child.ChildValue}"), Smart.Format("{Child:{ParentValue} - {Child.ChildValue}|}", nestedObject));
+            Assert.AreEqual(string.Format($"{nestedObject.ParentValue} - {nestedObject.Child.ChildValue}"), smart.Format("{Child:{ParentValue} - {Child.ChildValue}|}", nestedObject));
 
             // Access to current scope, although outer scope variable with same name exists
-            Assert.AreNotEqual(string.Format($"{nestedObject.IdenticalName} - {nestedObject.Child.IdenticalName}"), Smart.Format("{Child:{IdenticalName} - {Child.IdenticalName}|}", nestedObject));
+            Assert.AreNotEqual(string.Format($"{nestedObject.IdenticalName} - {nestedObject.Child.IdenticalName}"), smart.Format("{Child:{IdenticalName} - {Child.IdenticalName}|}", nestedObject));
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Core/SmartStaticTests.cs
+++ b/src/SmartFormat.Tests/Core/SmartStaticTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Settings;
+using SmartFormat.Extensions;
+using SmartFormat.Utilities;
+
+namespace SmartFormat.Tests.Core
+{
+    /// <summary>
+    /// Unit test must never use the static versions of <see cref="Smart"/>.
+    /// This would make tests not repeatable.
+    /// </summary>
+    [TestFixture]
+    public class SmartStaticTests
+    {
+        [Test]
+        public void Smart_Format_One_Arg()
+        {
+            Assert.That(Smart.Format("{0}", "SMART"), Is.EqualTo("SMART"));
+        }
+
+        [Test]
+        public void Smart_Format_Two_Args()
+        {
+            Assert.That(Smart.Format("{0} {1}", "VERY","SMART"), Is.EqualTo("VERY SMART"));
+        }
+
+        [Test]
+        public void Smart_Format_Three_Args()
+        {
+            Assert.That(Smart.Format("{0} {1} {2}", "THIS","IS","SMART"), Is.EqualTo("THIS IS SMART"));
+        }
+
+        [Test]
+        public void Smart_Format_With_FormatProvider()
+        {
+            Assert.That(Smart.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", "This","is","culture"), Is.EqualTo("This is culture"));
+        }
+
+        [Test]
+        public void Smart_Default()
+        {
+            Smart.Default = new SmartFormatter(new SmartSettings {StringFormatCompatibility = !new SmartSettings().StringFormatCompatibility});
+            Assert.That(Smart.Default.Settings.StringFormatCompatibility, Is.EqualTo(!new SmartSettings().StringFormatCompatibility));
+            Smart.Default = Smart.CreateDefaultSmartFormat(); // reset
+        }
+    }
+}

--- a/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
@@ -10,8 +10,6 @@ namespace SmartFormat.Tests.Extensions
     [TestFixture]
     public class ChooseFormatterTests
     {
-        private SmartFormatter _formatter = Smart.CreateDefaultSmartFormat();
-
         [TestCase("{0:choose(1|2|3):one|two|three}", 1, "one")]
         [TestCase("{0:choose(1|2|3):one|two|three}", 2, "two")]
         [TestCase("{0:choose(1|2|3):one|two|three}", 3, "three")]
@@ -32,7 +30,8 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(True|False):yep|nope}", false, "nope")]
         public void Choose_should_work_with_numbers_strings_and_booleans(string format, object arg0, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
 
         [TestCase("{0:choose(true|True):one|two|default}", true, "two")]
@@ -43,7 +42,8 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(ignore|IGNORE):one|two|default}", SmartFormat.Core.Settings.FormatErrorAction.Ignore, "default")]
         public void Choose_should_be_case_sensitive(string format, object arg0, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
         
         [TestCase("{0:choose(1|2|3):one|two|three|default}", 1, "one")]
@@ -56,7 +56,8 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(1|2|3):one|two|three|default}", "whatever", "default")]
         public void Choose_should_default_to_the_last_item(string format, object arg0, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
 
         [TestCase("{0:choose(Male|Female):man|woman}", Gender.Male, "man")]
@@ -65,7 +66,8 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(Male):man|woman}", Gender.Female, "woman")]
         public void Choose_should_work_with_enums(string format, object arg0, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
         
         [TestCase("{0:choose(null):nothing|{}}", null, "nothing")]
@@ -75,15 +77,17 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(null|5):nothing|five|{}}", 6, "6")]
         public void Choose_has_a_special_case_for_null(string format, object arg0, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
 
         [TestCase("{0:choose(1|2):1|2}", 99)]
         [TestCase("{0:choose(1):1}", 99)]
         public void Choose_throws_when_choice_is_invalid(string format, object arg0)
         {
-            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
-            Assert.Throws<FormattingException>(() => _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            Assert.Throws<FormattingException>(() => smart.Format(format, arg0));
         }
 
         // Too few choices:
@@ -94,8 +98,9 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:choose(1|2):1|2|3|4}", 1)]
         public void Choose_throws_when_choices_are_too_few_or_too_many(string format, object arg0)
         {
-            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
-            Assert.Throws<FormattingException>(() => _formatter.Format(format, arg0));
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            Assert.Throws<FormattingException>(() => smart.Format(format, arg0));
         }
 
     }

--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -23,7 +23,8 @@ namespace SmartFormat.Tests.Extensions
             };
 
             var args = new object[] {0, 1, 2, 3, -1, -2};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
         [Test]
         public void Test_Enum()
@@ -40,7 +41,8 @@ namespace SmartFormat.Tests.Extensions
             };
 
             var args = new object[] {TestFactory.GetPerson(), TestFactory.GetPerson(), new DateTime(1111,1,1,1,1,1), new DateTime(5555,5,5,5,5,5)};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]
@@ -56,7 +58,8 @@ namespace SmartFormat.Tests.Extensions
             };
 
             var args = new object[]{false, true};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]
@@ -73,7 +76,8 @@ namespace SmartFormat.Tests.Extensions
 
             // only the date part will be compared
             var args = new object[] {new DateTime(1111,1,1,1,1,1),SystemTime.Now(),new DateTime(5555,5,5,5,5,5)};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
         [Test]
         public void Test_DateTimeOffset_Dates()
@@ -90,7 +94,8 @@ namespace SmartFormat.Tests.Extensions
             // only the date part will be compared
             var args = new object[]
                 {SystemTime.OffsetNow().AddDays(-1), SystemTime.OffsetNow(), SystemTime.OffsetNow().AddDays(1)};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]
@@ -106,7 +111,8 @@ namespace SmartFormat.Tests.Extensions
             };
 
             var args = new object[] {new TimeSpan(-1,-1,-1,-1,-1), TimeSpan.Zero,new TimeSpan(5,5,5,5,5)};
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [TestCase("{0:cond:{}|Empty}", "Hello")]
@@ -115,7 +121,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Strings(string format, string expected)
         {
             var args = new object[] { "Hello", "", null! };
-            Smart.Default.Test(format, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(format, args, expected);
         }
 
         [TestCase("{0:cond:{}|Null}", "{ NotNull = True }")] // 'expected' comes from the default formatter, writing the anonymous type with 'ToString()'
@@ -123,7 +130,8 @@ namespace SmartFormat.Tests.Extensions
         public void Test_Object(string format, string expected)
         {
             var args = new object[] {new {NotNull = true}, null!};
-            Smart.Default.Test(format, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(format, args, expected);
         }
 
         [Test]
@@ -160,15 +168,16 @@ namespace SmartFormat.Tests.Extensions
                 "Senior Citizen",
                 "Crazy Old",
             };
-
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [TestCase("{0:part(s)|car}", true, "part(s)")]
         [TestCase("{0:part(s)|car}", false, "car")]
         public void Syntax_should_not_be_confused_with_named_formatters(string format, object arg0, string expectedOutput)
         {
-            var actualOutput = Smart.Format(format, arg0);
+            var smart = Smart.CreateDefaultSmartFormat();
+            var actualOutput = smart.Format(format, arg0);
             Assert.AreEqual(expectedOutput, actualOutput);
         }
     }

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -31,23 +31,26 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Simple_List()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var items = new[] { "one", "two", "three" };
-            var result = Smart.Default.Format("{0:list:{}|, |, and }", new object[] { items }); // important: not only "items" as the parameter
+            var result = smart.Format("{0:list:{}|, |, and }", new object[] { items }); // important: not only "items" as the parameter
             Assert.AreEqual("one, two, and three", result);
         }
 
         [Test]
         public void Empty_List()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var items = Array.Empty<string>();
-            var result = Smart.Default.Format("{0:list:{}|, |, and }", new object[] { items });
+            var result = smart.Format("{0:list:{}|, |, and }", new object[] { items });
             Assert.AreEqual(string.Empty, result);
         }
 
         [Test]
         public void Null_List()
         {
-            var result = Smart.Default.Format("{TheList?:list:{}|, |, and }", new { TheList = default(object)});
+            var smart = Smart.CreateDefaultSmartFormat();
+            var result = smart.Format("{TheList?:list:{}|, |, and }", new { TheList = default(object)});
             Assert.AreEqual(string.Empty, result);
         }
 
@@ -65,19 +68,20 @@ namespace SmartFormat.Tests.Extensions
             {
                 Persons = data.Where(p => p.Gender == "M")
             };
-
-            Smart.Default.Settings.StringFormatCompatibility = false; // mandatory for this test case because of consecutive curly braces
-            Smart.Default.Settings.Formatter.ErrorAction = SmartFormat.Core.Settings.FormatErrorAction.ThrowError;
-            Smart.Default.Settings.Parser.ErrorAction = SmartFormat.Core.Settings.ParseErrorAction.ThrowError;
+            
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.StringFormatCompatibility = false; // mandatory for this test case because of consecutive curly braces
+            smart.Settings.Formatter.ErrorAction = SmartFormat.Core.Settings.FormatErrorAction.ThrowError;
+            smart.Settings.Parser.ErrorAction = SmartFormat.Core.Settings.ParseErrorAction.ThrowError;
 
             // Note: it's faster to add the named formatter, than finding it implicitly by "trial and error".
-            var result = Smart.Default.Format("{0:list:{Name}|, |, and }", new object[] { data }); // Person A, Person B, and Person C
+            var result = smart.Format("{0:list:{Name}|, |, and }", new object[] { data }); // Person A, Person B, and Person C
             Assert.AreEqual("Person A, Person B, and Person C", result);
-            result = Smart.Default.Format("{0:list:{Name}|, |, and }", model.Persons);  // Person A, and Person C
+            result = smart.Format("{0:list:{Name}|, |, and }", model.Persons);  // Person A, and Person C
             Assert.AreEqual("Person A, and Person C", result);
-            result = Smart.Default.Format("{0:list:{Name}|, |, and }", data.Where(p => p.Gender == "F"));  // Person B
+            result = smart.Format("{0:list:{Name}|, |, and }", data.Where(p => p.Gender == "F"));  // Person B
             Assert.AreEqual("Person B", result);
-            result = Smart.Default.Format("{0:{Persons:list:{Name}|, }}", model); // Person A, and Person C
+            result = smart.Format("{0:{Persons:list:{Name}|, }}", model); // Person A, and Person C
             Assert.AreEqual("Person A, Person C", result);
         }
 
@@ -89,8 +93,9 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{4:list:N2|, |, and }","1.00, 2.00, 3.00, 4.00, and 5.00")]
         public void FormatTest(string format, string expected)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var args = GetArgs();
-            Smart.Default.Test(new[] {format}, args, new[] {expected});
+            smart.Test(new[] {format}, args, new[] {expected});
 
         }
 
@@ -100,16 +105,18 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:list:({})|, |, and }", "(A), (B), (C), (D), and (E)")]
         public void NestedFormatTest(string format, string expected)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var args = GetArgs();
-            Smart.Default.Test(new[] {format}, args, new[] {expected});
+            smart.Test(new[] {format}, args, new[] {expected});
         }
         [TestCase("{2:list:{:{FirstName}}|, }", "Jim, Pam, Dwight")]
         [TestCase("{3:list:{:M/d/yyyy} |}", "1/1/2000 10/10/2010 5/5/5555 ")]
         [TestCase("{2:list:{:{FirstName}'s friends: {Friends:list:{FirstName}|, }}|; }", "Jim's friends: Dwight, Michael; Pam's friends: Dwight, Michael; Dwight's friends: Michael")]
         public void NestedArraysTest(string format, string expected)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var args = GetArgs();
-            Smart.Default.Test(new[] {format}, args, new[] {expected});
+            smart.Test(new[] {format}, args, new[] {expected});
         }
 
         [Test] /* added due to problems with [ThreadStatic] see: https://github.com/axuno/SmartFormat.NET/pull/23 */
@@ -118,6 +125,7 @@ namespace SmartFormat.Tests.Extensions
             // Old test did not show wrong Index value - it ALWAYS passed even when using ThreadLocal<int> or [ThreadStatic] respectively:
             // const string format = "{wheres.Count::>0? where |}{wheres:{}| and }";
             const string format = "Wheres-Index={Index}.";
+            var smart = Smart.CreateDefaultSmartFormat();
 
             var wheres = new List<string>{"test1 = test1", "test2 = test2"};
             
@@ -127,7 +135,7 @@ namespace SmartFormat.Tests.Extensions
                 tasks.Add(Task.Factory.StartNew(val =>
                 {
                     Thread.Sleep(5 * (int)(val ?? 100));
-                    string ret = Smart.Default.Format(format, wheres);
+                    string ret = smart.Format(format, wheres);
                     Thread.Sleep(5 * (int)(val ?? 100)); /* add some delay to force ThreadPool swapping */
                     return ret;
                 }, i));
@@ -165,14 +173,16 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{Index}", "-1")] // Index can be used out-of-context, but should always be -1
         public void TestIndex(string format, string expected)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var args = GetArgs();
-            Smart.Default.Test(new[] {format}, args, new[] {expected});
+            smart.Test(new[] {format}, args, new[] {expected});
         }
 
         [Test]
         public void Test_Not_An_IList_Argument()
         {
-            Assert.That(() => Smart.Format("{0:list:{}|, |, and }", "not a list"),
+            var smart = Smart.CreateDefaultSmartFormat();
+            Assert.That(() => smart.Format("{0:list:{}|, |, and }", "not a list"),
                 Throws.Exception.TypeOf<FormattingException>().And.Message
                     .Contains("No suitable Formatter"));
         }

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -12,11 +12,12 @@ namespace SmartFormat.Tests.Extensions
     {
         private void TestAllResults(CultureInfo cultureInfo, string format, ExpectedResults expectedValuesAndResults)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             foreach (var test in expectedValuesAndResults)
             {
                 var value = test.Key;
                 var expected = test.Value;
-                var actual = Smart.Format(cultureInfo, format, value);
+                var actual = smart.Format(cultureInfo, format, value);
 
                 Assert.That(actual, Is.EqualTo(expected));
                 Debug.WriteLine(actual);
@@ -66,6 +67,7 @@ namespace SmartFormat.Tests.Extensions
              * but actually declaring them as u* doesn't.
              */
 
+            var smart = Smart.CreateDefaultSmartFormat();
             const string format = "There {0:plural(en):is|are} {0} {0:plural(en):item|items} remaining";
 
             var expectedResults = new[]
@@ -77,19 +79,19 @@ namespace SmartFormat.Tests.Extensions
 
             for (ushort i = 0; i < expectedResults.Length; i++)
             {
-                var actualResult = Smart.Format(format, i);
+                var actualResult = smart.Format(format, i);
                 Assert.AreEqual(expectedResults[i], actualResult);
             }
 
             for (uint i = 0; i < expectedResults.Length; i++)
             {
-                var actualResult = Smart.Format(format, i);
+                var actualResult = smart.Format(format, i);
                 Assert.AreEqual(expectedResults[i], actualResult);
             }
 
             for (ulong i = 0; i < (ulong)expectedResults.Length; i++)
             {
-                var actualResult = Smart.Format(format, i);
+                var actualResult = smart.Format(format, i);
                 Assert.AreEqual(expectedResults[i], actualResult);
             }
         }
@@ -191,7 +193,8 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0} {0:plural(en):zero|one|many} {0:plural(pl):miesiąc|miesiące|miesięcy}", 5, "5 many miesięcy")]
         public void NamedFormatter_should_use_specific_language(string format, object arg0, string expectedResult)
         {
-            var actualResult = Smart.Format(format, arg0);
+            var smart = Smart.CreateDefaultSmartFormat();
+            var actualResult = smart.Format(format, arg0);
             Assert.AreEqual(expectedResult, actualResult);
         }
 
@@ -201,21 +204,23 @@ namespace SmartFormat.Tests.Extensions
         [TestCase("{0:plural:zero|one|many}", new[] { "alice", "bob" }, "many")]
         public void Test_should_allow_ienumerable_parameter(string format, object arg0, string expectedResult)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var culture = new CultureInfo("en-US");
-            var actualResult = Smart.Format(culture, format, arg0);
+            var actualResult = smart.Format(culture, format, arg0);
             Assert.AreEqual(expectedResult, actualResult);
         }
 
         [Test]
         public void Test_With_CustomPluralRuleProvider()
         {
-            var actualResult = Smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("de")), "{0:plural:Frau|Frauen}", new string[2], "more");
+            var smart = Smart.CreateDefaultSmartFormat();
+            var actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("de")), "{0:plural:Frau|Frauen}", new string[2], "more");
             Assert.AreEqual("Frauen", actualResult);
 
-            actualResult = Smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[2], "more");
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[2], "more");
             Assert.AreEqual("people", actualResult);
 
-            actualResult = Smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[1], "one");
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[1], "one");
             Assert.AreEqual("person", actualResult);
         }
     }

--- a/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionFormatterTests.cs
@@ -46,7 +46,8 @@ namespace SmartFormat.Tests.Extensions
                 "Nested: Michael 7 Scranton Pennsylvania"
             };
             var args = GetArgs();
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]
@@ -146,7 +147,8 @@ namespace SmartFormat.Tests.Extensions
             var args = new object[] {
                 new MiscObject(),
             };
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Extensions/SystemTextJsonSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/SystemTextJsonSourceTests.cs
@@ -94,16 +94,14 @@ namespace SmartFormat.Tests.Extensions
         public void Format_Complex_Json()
         {
             var jObject = JsonDocument.Parse(JsonComplex.Replace("'", "\"")).RootElement;
-            var savedSetting = Smart.Default.Settings.CaseSensitivity;
-            Smart.Default.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
             Assert.Multiple(() =>
             {
                 var smart = GetFormatterWithJsonSource();
+                smart.Settings.CaseSensitivity = CaseSensitivityType.CaseSensitive;
                 Assert.AreEqual("50.00", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[0].Products[0].Price:0.00}", jObject));
                 Assert.AreEqual("True", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[0].OnStock}", jObject));
                 Assert.AreEqual("False", smart.Format(CultureInfo.InvariantCulture, "{Manufacturers[1].Products[1].OnStock}", jObject));
             });
-            Smart.Default.Settings.CaseSensitivity = savedSetting;
         }
 
         [Test]

--- a/src/SmartFormat.Tests/Extensions/TimeFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/TimeFormatterTests.cs
@@ -11,19 +11,17 @@ namespace SmartFormat.Tests.Extensions
     [TestFixture]
     public class TimeFormatterTests
     {
-        private readonly SmartFormatter _smart;
-
         public TimeFormatterTests()
         {
-            _smart = Smart.CreateDefaultSmartFormat();
-            _smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
-            _smart.Settings.Parser.ErrorAction = ParseErrorAction.ThrowError;
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            smart.Settings.Parser.ErrorAction = ParseErrorAction.ThrowError;
 
-            var timeFormatter = _smart.FormatterExtensions.FirstOrDefault(fmt => fmt.Names.Contains("time")) as TimeFormatter;
+            var timeFormatter = smart.FormatterExtensions.FirstOrDefault(fmt => fmt.Names.Contains("time")) as TimeFormatter;
             if (timeFormatter == null)
             {
                 timeFormatter = new TimeFormatter("en");
-                _smart.AddExtensions(timeFormatter);
+                smart.AddExtensions(timeFormatter);
             }
         }
 
@@ -74,7 +72,8 @@ namespace SmartFormat.Tests.Extensions
                 "5 days",
             };
             var args = GetArgs();
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [Test]
@@ -103,7 +102,8 @@ namespace SmartFormat.Tests.Extensions
                 "3d 3s",
             };
             var args = GetArgs();
-            Smart.Default.Test(formats, args, expected);
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Test(formats, args, expected);
         }
 
         [TestCase(0)]
@@ -113,16 +113,17 @@ namespace SmartFormat.Tests.Extensions
         [TestCase(-23)]
         public void TimeSpanFromGivenTimeToCurrentTime(int diffHours)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             // test will work in any TimeZone
             var now = DateTime.Now;
             var dateTime = now.AddHours(diffHours);
             SystemTime.SetDateTime(now);
             var format = "{0:time(abbr hours noless)}";
             // The difference to current time with a DateTime as an argument
-            var actual = _smart.Format(format, dateTime);
+            var actual = smart.Format(format, dateTime);
             Assert.AreEqual($"{diffHours * -1}h", actual);
             // Make sure that logic for TimeSpan and DateTime arguments are the same
-            Assert.AreEqual(actual, _smart.Format(format, now - dateTime));
+            Assert.AreEqual(actual, smart.Format(format, now - dateTime));
             Console.WriteLine("Success: \"{0}\" => \"{1}\"", format, actual);
             SystemTime.ResetDateTime();
         }
@@ -134,16 +135,17 @@ namespace SmartFormat.Tests.Extensions
         [TestCase(-23)]
         public void TimeSpanOffsetFromGivenTimeToCurrentTime(int diffHours)
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             // test will work in any TimeZone
             var now = DateTimeOffset.Now;
             var dateTimeOffset = now.AddHours(diffHours);
             SystemTime.SetDateTimeOffset(now);
             var format = "{0:time(abbr hours noless)}";
             // The difference to current time with a DateTimeOffset as an argument
-            var actual = _smart.Format(format, dateTimeOffset);
+            var actual = smart.Format(format, dateTimeOffset);
             Assert.AreEqual($"{diffHours * -1}h", actual);
             // Make sure that logic for TimeSpan and DateTime arguments are the same
-            Assert.AreEqual(actual, _smart.Format(format, now - dateTimeOffset));
+            Assert.AreEqual(actual, smart.Format(format, now - dateTimeOffset));
             Console.WriteLine("Success: \"{0}\" => \"{1}\"", format, actual);
             SystemTime.ResetDateTime();
         }

--- a/src/SmartFormat.Tests/Extensions/XmlSourceTest.cs
+++ b/src/SmartFormat.Tests/Extensions/XmlSourceTest.cs
@@ -43,9 +43,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_SingleLevelXml_Replaced()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = Smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
+            var res = smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe Doe", res);
         }
@@ -54,9 +55,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_SingleLevelXml_CanAccessWithIndex0()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = Smart.Format("Mr. {FirstName.0:xml:}", xmlEl);
+            var res = smart.Format("Mr. {FirstName.0:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe", res);
         }
@@ -65,9 +67,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_XmlWithNamespaces_IgnoringNamespace()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(OneLevelXmlWithNameSpaces);
             // act
-            var res = Smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
+            var res = smart.Format("Mr. {FirstName:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe Doe", res);
         }
@@ -75,12 +78,12 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Format_SingleLevelXml_TemplateWithCurlyBraces_Escaped()
         {
-            var sf = Smart.CreateDefaultSmartFormat();
-            sf.Settings.StringFormatCompatibility = false;
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.StringFormatCompatibility = false;
             // arrange
             var xmlEl = XElement.Parse(OneLevelXml);
             // act
-            var res = sf.Format("Mr. \\{{LastName:xml:}\\}", xmlEl);
+            var res = smart.Format("Mr. \\{{LastName:xml:}\\}", xmlEl);
             // assert
             Assert.AreEqual("Mr. {Doe}", res);
         }
@@ -89,9 +92,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_MultipleElement_AccessibleByIndex()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("Mr. {FirstName.1:xml:} {LastName:xml:}", xmlEl);
+            var res = smart.Format("Mr. {FirstName.1:xml:} {LastName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Jack Doe", res);
         }
@@ -100,9 +104,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_MultipleElement_WithoutIndexesReturnsFirst()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("Mr. {FirstName:xml:}", xmlEl);
+            var res = smart.Format("Mr. {FirstName:xml:}", xmlEl);
             // assert
             Assert.AreEqual("Mr. Joe", res);
         }
@@ -111,9 +116,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_MultipleElement_FormatsCount()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("There{FirstName.Count:cond: is {} Doe | are {} Does}", xmlEl);
+            var res = smart.Format("There{FirstName.Count:cond: is {} Doe | are {} Does}", xmlEl);
             // assert
             Assert.AreEqual("There are 3 Does", res);
         }
@@ -122,9 +128,10 @@ namespace SmartFormat.Tests.Extensions
         public void Format_MultipleElement_FormatsAsList()
         {
             // arrange
+            var smart = Smart.CreateDefaultSmartFormat();
             var xmlEl = XElement.Parse(XmlMultipleFirstNameStr);
             // act
-            var res = Smart.Format("There are{FirstName:list: {}|,|, and} Doe", xmlEl);
+            var res = smart.Format("There are{FirstName:list: {}|,|, and} Doe", xmlEl);
             // assert
             Assert.AreEqual("There are Joe, Jack, and Jim Doe", res);
         }
@@ -132,11 +139,12 @@ namespace SmartFormat.Tests.Extensions
         [Test]
         public void Format_TwoLevelXml_InvalidSelectors_Throws()
         {
-            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.Settings.Formatter.ErrorAction = FormatErrorAction.ThrowError;
             // arrange
             var xmlEl = XElement.Parse(TwoLevelXml);
             // act
-            Assert.Throws<FormattingException>(() => Smart.Format("{SomethingNonExisting}{EvenMore}", xmlEl));
+            Assert.Throws<FormattingException>(() => smart.Format("{SomethingNonExisting}{EvenMore}", xmlEl));
         }
     }
 }

--- a/src/SmartFormat.Tests/Utilities/FormatDelegateTests.cs
+++ b/src/SmartFormat.Tests/Utilities/FormatDelegateTests.cs
@@ -36,26 +36,28 @@ namespace SmartFormat.Tests.Utilities
         [Test]
         public void FormatDelegate_Works_WithSmartFormat()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var formatDelegate = new FormatDelegate((text) => HtmlActionLink(text ?? "null", "SomePage"));
 
-            Assert.That(Smart.Format("Please visit {0:this page} for more info.", formatDelegate)
+            Assert.That(smart.Format("Please visit {0:this page} for more info.", formatDelegate)
                         , Is.EqualTo("Please visit <a href='www.example.com/SomePage'>this page</a> for more info."));
 
-            Assert.That(Smart.Format("And {0:this other page} is cool too.", formatDelegate)
+            Assert.That(smart.Format("And {0:this other page} is cool too.", formatDelegate)
                         , Is.EqualTo("And <a href='www.example.com/SomePage'>this other page</a> is cool too."));
 
-            Assert.That(Smart.Format("There are {0:two} {0:links} in this one.", formatDelegate)
+            Assert.That(smart.Format("There are {0:two} {0:links} in this one.", formatDelegate)
                         , Is.EqualTo("There are <a href='www.example.com/SomePage'>two</a> <a href='www.example.com/SomePage'>links</a> in this one."));
         }
 
         [Test]
         public void FormatDelegate_WithCulture_WithSmartFormat()
         {
+            var smart = Smart.CreateDefaultSmartFormat();
             var amount = (decimal) 123.456;
             var c = new CultureInfo("fr-FR");
             // Only works for indexed placeholders
             var formatDelegate = new FormatDelegate((text, culture) => GetAnswer("The amount is: ", amount, c));
-            Assert.That(Smart.Format("{0}", formatDelegate)
+            Assert.That(smart.Format("{0}", formatDelegate)
                 , Is.EqualTo($"The amount is: {amount.ToString(c)}"));
         }
     }


### PR DESCRIPTION
* No more class instance variables for SmartFormatter
* No usage of static Smart.Format methods
* No usage of static Smart.Default

Now all tests can run in any sequence without any mutual interference