### PR TITLE
Refactored PluralLocalizationFormatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,17 @@ Best results can only be expected with clean HTML: balanced opening and closing 
 
 SmartFormat is not a fully-fledged HTML parser. If this is required, use [AngleSharp](https://anglesharp.github.io/) or [HtmlAgilityPack](https://html-agility-pack.net/).
 
+
+### 19. Refactored `PluralLocalizationFormatter`
+
+* Constructor with string argument for default language is obsolete.
+* Property `DefaultTwoLetterISOLanguageName` is obsolete.
+* Culture is now determined in this sequence (same as with `LocalizationFormatter`):<br/>
+  a) Get the culture from the `FormattingInfo.FormatterOptions`.<br/>
+  b) Get the culture from the `IFormatProvider` argument (which may be a `CultureInfo`) to `SmartFormatter.Format(IFormatProvider, string, object?[])`<br/>
+  c) The CultureInfo.CurrentUICulture<br/>
+
+
 v2.7.0
 ===
 * **Fixed** broken backward compatibilty introduced in v2.6.2 (issues referenced in [#148](https://github.com/axuno/SmartFormat/issues/148), [#147](https://github.com/axuno/SmartFormat/issues/147), [#143](https://github.com/axuno/SmartFormat/issues/143)).

--- a/src/SmartFormat.Tests/Core/FormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
@@ -146,8 +147,11 @@ namespace SmartFormat.Tests.Core
             // Note: If pluralization AND conditional formatters are registers, the formatter
             //       name MUST be included in the format string, because both could return successful evaluation
             // Here, we register only pluralization:
-            formatter.AddExtensions(new PluralLocalizationFormatter("en"){CanAutoDetect = markAsDefault}, new DefaultFormatter());
-            
+            var savedCulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en");
+            formatter.AddExtensions(new PluralLocalizationFormatter{CanAutoDetect = markAsDefault}, new DefaultFormatter());
+            CultureInfo.CurrentUICulture = savedCulture;
+
             var result = formatter.Format(format, data);
             
             Assert.That(result, numOfPeople == 1 ? Is.EqualTo("There is a person.") : Is.EqualTo("There are 2 people."));

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -134,7 +134,7 @@ namespace SmartFormat
             );
             formatter.AddExtensions(
                 (IFormatter) listSourceAndFormatter, // ListFormatter should be one of the first formatter extensions
-                new PluralLocalizationFormatter("en"),
+                new PluralLocalizationFormatter(),
                 new ConditionalFormatter(),
                 new IsMatchFormatter(),
                 new NullFormatter(),


### PR DESCRIPTION
Refactored `PluralLocalizationFormatter`

* Constructor with string argument for default language is obsolete.
* Property `DefaultTwoLetterISOLanguageName` is obsolete.
* Culture is now determined in this sequence (same as with `LocalizationFormatter`):<br/>
  a) Get the culture from the `FormattingInfo.FormatterOptions`.<br/>
  b) Get the culture from the `IFormatProvider` argument (which may be a `CultureInfo`) to `SmartFormatter.Format(IFormatProvider, string, object?[])`<br/>
  c) The `CultureInfo.CurrentUICulture`<br/>