### PR TITLE
Fix: Parser wont throw on illegal selector chars

### DIFF
--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -66,6 +66,25 @@ namespace SmartFormat.Tests.Core
             Assert.Throws<ParsingErrors>(() => formatter.Test(format, args, "Error"));
         }
 
+        [TestCase("{V(LU)}")] // braces are illegal
+        [TestCase("{V LU }")] // blanks are illegal
+        [TestCase("{VĀLUĒ}")] // 0x100 and 0x112 are illegal chars
+        public void Parser_Throws_On_Illegal_Selector_Chars(string format)
+        {
+            var parser = GetRegularParser();
+            try
+            {
+                parser.ParseFormat(format);
+                Assert.That(true, "Should throw");
+            }
+            catch (Exception e)
+            {
+                // Throws, because selector contains 2 illegal characters
+                Assert.That(e, Is.InstanceOf<ParsingErrors>());
+                Assert.That(((ParsingErrors)e).Issues.Count, Is.EqualTo(2));
+            }
+        }
+
         [Test]
         public void Parser_Exception_ErrorDescription()
         {

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -613,7 +613,7 @@ namespace SmartFormat.Core.Parsing
                 // Ensure the selector characters are valid:
                 if (!_validSelectorChars.Contains(inputChar))
                     parsingErrors.AddIssue(_resultFormat,
-                        $"'0x{Convert.ToByte(inputChar):X}': " +
+                        $"'0x{Convert.ToUInt32(inputChar):X}': " +
                         _parsingErrorText[ParsingError.InvalidCharactersInSelector],
                         _index.Current, _index.SafeAdd(_index.Current, 1));
             }
@@ -636,7 +636,7 @@ namespace SmartFormat.Core.Parsing
                 currentPlaceholder.AddSelector(new Selector(Settings, _inputFormat, _index.LastEnd, _index.Current,_index.Operator, _index.Selector));
             else if (_index.Operator != _index.Current) // the selector only contains illegal ("trailing") operator characters
                 parsingErrors.AddIssue(_resultFormat,
-                    $"'0x{Convert.ToByte(_inputFormat[_index.Operator]):X}': " +
+                    $"'0x{Convert.ToInt32(_inputFormat[_index.Operator]):X}': " +
                     _parsingErrorText[ParsingError.TrailingOperatorsInSelector],
                     _index.Operator, _index.Current);
             _index.LastEnd = _index.SafeAdd(_index.Current, 1);


### PR DESCRIPTION
Fixes #211 
An unexpected `ThrowByteOverflowException` was thrown, if the illegal character was not 8-bit.
This is resolved.
