### PR TITLE
Backport fixes from v3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Latest Changes
 ====
 
+v2.7.1
+===
+* **Fixed**: [#179](https://github.com/axuno/SmartFormat/issues/179) DualFromZeroToTwo plural rule. Thanks to [@OhSoGood](https://github.com/OhSoGood)
+* **Fixed**: [#211](https://github.com/axuno/SmartFormat/issues/211) Illegal placeholder characters that are not 8-bit, will no more throw unexpected `ThrowByteOverflowException`. Thanks to [@bogatykh](https://github.com/bogatykh)
+
 v2.7.0
 ===
 * **Fixed** broken backward compatibilty introduced in v2.6.2 (issues referenced in [#148](https://github.com/axuno/SmartFormat/issues/148), [#147](https://github.com/axuno/SmartFormat/issues/147), [#143](https://github.com/axuno/SmartFormat/issues/143)).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.7.0.{build}
+version: 2.7.1.{build}
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 image: Visual Studio 2019
@@ -8,7 +8,7 @@ build_script:
 - ps: dotnet add .\SmartFormat.Tests\SmartFormat.Tests.csproj package AltCover
 - ps: dotnet build SmartFormat.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618
 - ps: |
-    $version = "2.7.0"
+    $version = "2.7.1"
     $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -401,7 +401,7 @@ namespace SmartFormat.Core.Parsing
                             currentPlaceholder.Selectors.Add(new Selector(Settings, format, lastI, i, operatorIndex,
                                 selectorIndex));
                         else if (operatorIndex != i)
-                            parsingErrors.AddIssue(current, $"'0x{Convert.ToByte(c):X}': " + parsingErrorText[ParsingError.TrailingOperatorsInSelector],
+                            parsingErrors.AddIssue(current, $"'0x{Convert.ToUInt32(c):X}': " + parsingErrorText[ParsingError.TrailingOperatorsInSelector],
                                 operatorIndex, i);
                         lastI = i + 1;
 
@@ -420,7 +420,7 @@ namespace SmartFormat.Core.Parsing
                             currentPlaceholder.Selectors.Add(new Selector(Settings, format, lastI, i, operatorIndex,
                                 selectorIndex));
                         else if (operatorIndex != i)
-                            parsingErrors.AddIssue(current, $"'0x{Convert.ToByte(c):X}': " + parsingErrorText[ParsingError.TrailingOperatorsInSelector],
+                            parsingErrors.AddIssue(current, $"'0x{Convert.ToUInt32(c):X}': " + parsingErrorText[ParsingError.TrailingOperatorsInSelector],
                                 operatorIndex, i);
                         lastI = i + 1;
 
@@ -439,7 +439,7 @@ namespace SmartFormat.Core.Parsing
                             || _alphanumericSelectors && ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z')
                             || _allowedSelectorChars.IndexOf(c) != -1;
                         if (!isValidSelectorChar)
-                            parsingErrors.AddIssue(current, $"'0x{Convert.ToByte(c):X}': " +  parsingErrorText[ParsingError.InvalidCharactersInSelector],
+                            parsingErrors.AddIssue(current, $"'0x{Convert.ToUInt32(c):X}': " +  parsingErrorText[ParsingError.InvalidCharactersInSelector],
                                 i, i + 1);
                     }
                 }

--- a/src/SmartFormat/SmartFormat.csproj
+++ b/src/SmartFormat/SmartFormat.csproj
@@ -3,8 +3,8 @@
     <PropertyGroup>
         <Description>A string composition library written in C# that can format data into a string with a minimal, intuitive syntax. It uses extensions to provide named placeholders, pluralization, gender conjugation, and time and list formatting.</Description>
         <AssemblyTitle>SmartFormat</AssemblyTitle>
-        <Version>2.7.0</Version>
-        <FileVersion>2.7.0</FileVersion>
+        <Version>2.7.1</Version>
+        <FileVersion>2.7.1</FileVersion>
         <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG</DefineConstants>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
* **Fixed**: [#179](https://github.com/axuno/SmartFormat/issues/179) DualFromZeroToTwo plural rule. Thanks to [@OhSoGood](https://github.com/OhSoGood)
* **Fixed**: [#211](https://github.com/axuno/SmartFormat/issues/211) Illegal placeholder characters that are not 8-bit, will no more throw unexpected `ThrowByteOverflowException`. Thanks to [@bogatykh](https://github.com/bogatykh)