### PR TITLE
Bugfix in Parser. Obsolete elements throw compile time errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@ Add unicode escape characters like `"\u1234"`. Thanks to [@karljj1](https://gith
 
 The mode can be set with `SmartSettings.StringFormatCompatibility`. By default, `SmartSettings.StringFormatCompatibility` is `false`. ([#173](https://github.com/axuno/SmartFormat/pull/173), [#175](https://github.com/axuno/SmartFormat/pull/175))
 
+Reasoning: The distinction was necessary because of syntax conflicts between SmartFormat extensions and `string.Format`. It brings a more concise and clear set of formatting rules and full `string.Format` compatibility even in "edge cases".
+
 **a) *Smart.Format* features mode**
    * Brings the full set of features implemented in *Smart.Format*
    * Curly braces are escaped the *Smart.Format* way with `\{` and `\}`.
@@ -369,17 +371,17 @@ SmartFormat is not a fully-fledged HTML parser. If this is required, use [AngleS
 
 SmartFormat makes heavy use of caching and object pooling for expensive operations, which both require `static` containers. 
 
-a) Instantiating `SmartFormatter`s from different threads: 
+#### a) Instantiating `SmartFormatter`s from different threads: 
+    
+With `SmartSettings.IsThreadSafeMode=true` **must** be set, so that thread safe containers are used. This brings an inherent performance penalty.
 
-    `SmartSettings.IsThreadSafeMode=true` **must** be set, so that thread safe containers are used. This brings an inherent performance penalty.
+**Note:** The simplified `Smart.Format(...)` API overloads use a static `SmartFormatter` instance which is **not** thread safe. Call `Smart.CreateDefaultSmartFormat()` to create a default `SmartFormatter`.
 
-     **Note:** The simplified `Smart.Format(...)` API overloads use a static `SmartFormatter` instance which is **not** thread safe. Call `Smart.CreateDefaultSmartFormat()` to create a default `Formatter`.
+#### b) Instantiating `SmartFormatter`s from a single thread: 
 
-a) Instantiating `SmartFormatter`s from a single thread: 
+With `SmartSettings.IsThreadSafeMode=false` **should** be set for avoiding the multithreading overhead and thus for best performance. 
 
-    `SmartSettings.IsThreadSafeMode=false` **should** be set for avoiding the multithreading overhead and thus for best performance. 
-
-    The simplified `Smart.Format(...)` API overloads are allowed here.
+The static `Smart.Format(...)` API overloads are allowed here.
 
 <a id="ObjectPooling"></a>
 ### 22. How to benefit from object pooling ([#229](https://github.com/axuno/SmartFormat/pull/229))
@@ -451,7 +453,7 @@ SmartFormat is the core package. It comes with the most frequently used extensio
 
 > **Breaking change:**
 > 
-> Note that only extensions marked (✔️) are included when calling `Smart.CreateDefaultFormatter(...)`. These default extensions differ from previous versions.
+> Note that only extensions marked (✔️) are included when calling `Smart.CreateDefaultFormatter(...)` amd also when using `Smart.Format(...)`. These default extensions differ from previously included extensions.
 
 Some extensions (like `PersistentVariablesSource` and `TemplateFormatter`) require configuration to be useful.
 

--- a/src/SmartFormat.Tests/Core/LiteralTextTests.cs
+++ b/src/SmartFormat.Tests/Core/LiteralTextTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SmartFormat.Core.Settings;
+using SmartFormat.Extensions;
 
 namespace SmartFormat.Tests.Core
 {
@@ -70,6 +71,27 @@ namespace SmartFormat.Tests.Core
             var result = smart.Format(@"{0:list:{}|\n|\nand }", new object[] { items });
             
             Assert.AreEqual("one\ntwo\nand three", result);
+        }
+
+        [Test, Description("Illegal escape sequence should always throw")]
+        public void IllegalEscapeSequenceThrowsException()
+        {
+            var smart = new SmartFormatter().AddExtensions(new DefaultSource()).AddExtensions(new DefaultFormatter());
+            Assert.That(code: () => {
+                smart.Format(@"\z Illegal escape sequence at the beginning of the text");
+            },Throws.ArgumentException.And.Message.Contains("escape sequence"));
+
+            Assert.That(code: () => {
+                smart.Format(@"Illegal escape sequence \z somewhere in text");
+            },Throws.ArgumentException.And.Message.Contains("escape sequence"));
+
+            Assert.That(code: () => {
+                smart.Format(@"Illegal escape sequence at end of line = \z");
+            }, Throws.ArgumentException.And.Message.Contains("escape sequence"));
+
+            Assert.That(code: () => {
+                smart.Format(@"Illegal escape sequence starts at end of line = \");
+            },Throws.ArgumentException.And.Message.Contains("escape sequence"));
         }
     }
 }

--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -24,7 +24,7 @@ namespace SmartFormat.Tests.Core
         [TestCase(" aaa {bbb.ccc: ddd {eee} fff } ggg ")]
         [TestCase("{aaa} {bbb}")]
         [TestCase("{}")]
-        [TestCase("{a:{b:{c:{d} } } }")]
+        [TestCase("{a:{b:{c:{d}}}}")]
         [TestCase("{a}")]
         [TestCase(" aaa {bbb_bbb.CCC} ddd ")]
         public void Basic_Parser_Test(string format)
@@ -430,7 +430,6 @@ namespace SmartFormat.Tests.Core
         public void Nested_format_with_literal_escaping()
         {
             var parser = GetRegularParser();
-            // necessary because of the consecutive }}}, which would otherwise be escaped as }} and lead to "missing brace" exception:
             var placeholders = parser.ParseFormat("{c1:{c2:{c3}}}");
 
             var c1 = (Placeholder) placeholders.Items[0];
@@ -547,14 +546,14 @@ namespace SmartFormat.Tests.Core
                 // Group Sel_1 is empty
                 Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_2"].Value));
                 // Concatenate because of regex simplification for 2 selectors
-                Assert.That(placeholder.Selectors[1].Operator.ToString(), Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value + reMatches[0].Groups["Sel_2_Op"].Value));
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value + reMatches[0].Groups["Sel_2_Op"].Value));
             }
             else
             {
                 Assert.That(placeholder.Selectors[0].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_0"].Value));
-                Assert.That(placeholder.Selectors[1].Operator.ToString(), Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
                 Assert.That(placeholder.Selectors[1].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_1"].Value));
-                Assert.That(placeholder.Selectors[1].Operator.ToString(), Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
+                Assert.That(placeholder.Selectors[1].Operator, Is.EqualTo(reMatches[0].Groups["Sel_1_Op"].Value));
                 Assert.That(placeholder.Selectors[2].ToString(), Is.EqualTo(reMatches[0].Groups["Sel_2"].Value));
             }
         }

--- a/src/SmartFormat.Tests/Core/StringFormatCompatibilityTests.cs
+++ b/src/SmartFormat.Tests/Core/StringFormatCompatibilityTests.cs
@@ -156,5 +156,13 @@ namespace SmartFormat.Tests.Core
             var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings {StringFormatCompatibility = true});
             Assert.That(formatter.Format(format, arg0), Is.EqualTo(string.Format(format, arg0)));
         }
+
+        [Test]
+        public void Escaped_Curly_Braces_At_Begin_And_End_Should_Work()
+        {
+            var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings {StringFormatCompatibility = true});
+            var result = formatter.Format("{{{0}}}", 99999);
+            Assert.That(result, Is.EqualTo($"{{{99999}}}"));
+        }
     }
 }

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -87,7 +87,6 @@ namespace SmartFormat.Tests.Extensions
                 Parser = new ParserSettings {ErrorAction = ParseErrorAction.ThrowError}
             });
 
-            // Note: it's faster to add the named formatter, than finding it implicitly by "trial and error".
             var result = smart.Format("{0:list:{Name}|, |, and }", new object[] { data }); // Person A, Person B, and Person C
             Assert.AreEqual("Person A, Person B, and Person C", result);
             result = smart.Format("{0:list:{Name}|, |, and }", model.Persons);  // Person A, and Person C

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -86,7 +86,7 @@ using SmartFormat.Pooling.SmartPools;
         /// <summary>
         /// Includes a-z and A-Z in the list of allowed selector chars.
         /// </summary>
-        [Obsolete("Alphanumeric selectors are always enabled")]
+        [Obsolete("Alphanumeric selectors are always enabled", true)]
         public void AddAlphanumericSelectors()
         {
             // Do nothing - this is the standard behavior
@@ -96,7 +96,7 @@ using SmartFormat.Pooling.SmartPools;
         /// Adds specific characters to the allowed selector chars.
         /// </summary>
         /// <param name="chars"></param>
-        [Obsolete("Use 'Settings.Parser.AddCustomSelectorChars' instead.")]
+        [Obsolete("Use 'Settings.Parser.AddCustomSelectorChars' instead.", true)]
         public void AddAdditionalSelectorChars(string chars)
         {
             _parserSettings.AddCustomSelectorChars(chars.ToCharArray());
@@ -108,7 +108,7 @@ using SmartFormat.Pooling.SmartPools;
         /// that splits the selectors.
         /// </summary>
         /// <param name="chars"></param>
-        [Obsolete("Use 'Settings.Parser.AddCustomOperatorChars' instead.")]
+        [Obsolete("Use 'Settings.Parser.AddCustomOperatorChars' instead.", true)]
         public void AddOperators(string chars)
         {
             _parserSettings.AddCustomOperatorChars(chars.ToCharArray());
@@ -433,9 +433,11 @@ using SmartFormat.Pooling.SmartPools;
 
             // See what is the next character
             var indexNextChar = _index.SafeAdd(_index.Current, 1);
+            if (indexNextChar >= _inputFormat.Length)
+                throw new ArgumentException($"Unrecognized escape sequence at the end of the literal");
 
             // **** Alternative brace escaping with { or } following the escape character ****
-            if (indexNextChar < _inputFormat.Length && (_inputFormat[indexNextChar] == _parserSettings.PlaceholderBeginChar || _inputFormat[indexNextChar] == _parserSettings.PlaceholderEndChar))
+            if (_inputFormat[indexNextChar] == _parserSettings.PlaceholderBeginChar || _inputFormat[indexNextChar] == _parserSettings.PlaceholderEndChar)
             {
                 // Finish the last text item:
                 if (_index.Current != _index.LastEnd) _resultFormat.Items.Add(LiteralTextPool.Instance.Get().Initialize(Settings, _resultFormat, _inputFormat, _index.LastEnd, _index.Current));

--- a/src/SmartFormat/Core/Settings/ErrorAction.cs
+++ b/src/SmartFormat/Core/Settings/ErrorAction.cs
@@ -10,7 +10,7 @@ namespace SmartFormat.Core.Settings
     /// <summary>
     /// Determines how format errors are handled.
     /// </summary>
-    [Obsolete("Use 'ParseErrorAction' or 'FormatErrorAction' instead.", false)]
+    [Obsolete("Use 'ParseErrorAction' or 'FormatErrorAction' instead.", true)]
     public enum ErrorAction
     {
         /// <summary>Throws an exception. This is only recommended for debugging, so that formatting errors can be easily found.</summary>

--- a/src/SmartFormat/Core/Settings/SmartSettings.cs
+++ b/src/SmartFormat/Core/Settings/SmartSettings.cs
@@ -45,7 +45,7 @@ namespace SmartFormat.Core.Settings
         /// Gets the <see cref="ErrorAction" /> to apply for the <see cref="SmartFormatter" />.
         /// The default is <see cref="ErrorAction.ThrowError"/>.
         /// </summary>
-        [Obsolete("Use 'SmartSettings.Formatter.ErrorAction' instead.", false)]
+        [Obsolete("Use 'SmartSettings.Formatter.ErrorAction' instead.", true)]
         public ErrorAction FormatErrorAction
         {
             get => (ErrorAction) Formatter.ErrorAction;
@@ -56,7 +56,7 @@ namespace SmartFormat.Core.Settings
         /// Gets the <see cref="ErrorAction" /> to apply for the <see cref="SmartFormat.Core.Parsing.Parser" />.
         /// The default is <see cref="ErrorAction.ThrowError"/>.
         /// </summary>
-        [Obsolete("Use 'SmartSettings.Parser.ErrorAction' instead.", false)]
+        [Obsolete("Use 'SmartSettings.Parser.ErrorAction' instead.", true)]
         public ErrorAction ParseErrorAction
         {
             get => (ErrorAction) Parser.ErrorAction;
@@ -76,7 +76,7 @@ namespace SmartFormat.Core.Settings
         /// If false, character string literals are not converted, just like with this string.Format:
         /// string.Format(@"\t")  will return the 2 characters "\" and "t"
         /// </summary>
-        [Obsolete("Use SmartSettings.Parser.ConvertCharacterStringLiterals instead", false)]
+        [Obsolete("Use SmartSettings.Parser.ConvertCharacterStringLiterals instead", true)]
         public bool ConvertCharacterStringLiterals
         {
             get => Parser.ConvertCharacterStringLiterals;

--- a/src/SmartFormat/Extensions/WellKnownExtensionTypes.cs
+++ b/src/SmartFormat/Extensions/WellKnownExtensionTypes.cs
@@ -35,8 +35,8 @@ namespace SmartFormat.Extensions
             { "SmartFormat.Extensions.XmlSource", 9000 },
             // sources for specific types must be in the list before ReflectionSource
             { "SmartFormat.Extensions.ReflectionSource", 10000 },
-            { "SmartFormat.Extensions.DefaultSource", 11000 },
-            { "SmartFormat.Extensions.KeyValuePairSource", 12000 }
+            { "SmartFormat.Extensions.KeyValuePairSource", 11000 },
+            { "SmartFormat.Extensions.DefaultSource", 12000 }
         };
 
         /// <summary>


### PR DESCRIPTION
* Fix: A single escape character at the end of the input string will now throw an `ArgumentException` with a comprehensive error message.
* Remainders from the v2.x API: All obsolete element usage creates a compile time error
* Updates for CHANGES.md