### PR TITLE
Remove magic leading colon for ConditionalFormatter

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -106,21 +106,23 @@ namespace SmartFormat.Tests.Extensions
             smart.Test(format, args, expected);
         }
 
-        [TestCase("{0::>0?Positive|<0?Negative|=0?Zero}, {1::>0?Positive|<0?Negative|=0?Zero}, {2::>0?Positive|<0?Negative|=0?Zero}", "Negative, Zero, Positive")]
-        [TestCase("{1::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]
-        [TestCase("{2::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]
-        [TestCase("{3::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Toddler")]
-        [TestCase("{4::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Toddler")]
-        [TestCase("{5::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Child")]
-        [TestCase("{6::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Pre-Teen")]
-        [TestCase("{7::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Teenager")]
-        [TestCase("{8::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Young Adult")]
-        [TestCase("{9::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Early Twenties")]
-        [TestCase("{10::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Adult")]
-        [TestCase("{11::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Senior Citizen")]
-        [TestCase("{12::<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Crazy Old")]
+        [TestCase("{0:cond:>0?Positive|<0?Negative|=0?Zero}, {1:cond:>0?Positive|<0?Negative|=0?Zero}, {2:cond:>0?Positive|<0?Negative|=0?Zero}", "Negative, Zero, Positive")]
+        [TestCase("{1:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]
+        [TestCase("{2:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]
+        [TestCase("{3:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Toddler")]
+        [TestCase("{4:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Toddler")]
+        [TestCase("{5:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Child")]
+        [TestCase("{6:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Pre-Teen")]
+        [TestCase("{7:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Teenager")]
+        [TestCase("{8:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Young Adult")]
+        [TestCase("{9:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Early Twenties")]
+        [TestCase("{10:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Adult")]
+        [TestCase("{11:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Senior Citizen")]
+        [TestCase("{12:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Crazy Old")]
         public void Test_ComplexCondition(string format, string expected)
         {
+            // ConditionalFormatter name "cond" must be included, because
+            // otherwise PluralLocalizationFormatter would be invoked
             var args = new object[] {-5, 0, 0.5, 1.0, 1.5, 5.0, 11.0M, 14.0f, 18, 22, 45, 60, 101};
 
             var smart = Smart.CreateDefaultSmartFormat();

--- a/src/SmartFormat/Extensions/ConditionalFormatter.cs
+++ b/src/SmartFormat/Extensions/ConditionalFormatter.cs
@@ -45,9 +45,6 @@ namespace SmartFormat.Extensions
             var format = formattingInfo.Format;
             var current = formattingInfo.CurrentValue;
             
-            // Ignore a leading ":", which is used to bypass the PluralLocalizationExtension
-            if (format?.BaseString.Length > 0 && format.BaseString[format.StartIndex] == ':') format = format.Substring(1);
-
             // See if the format string contains un-nested "|":
             var parameters = format is not null ? format.Split(SplitChar) : new List<Format>(0);
 

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -82,9 +82,8 @@ namespace SmartFormat.Extensions
             var format = formattingInfo.Format;
             var current = formattingInfo.CurrentValue;
             
-            // Ignore formats that start with "?" (this can be used to bypass this extension)
-            if (format == null || format.BaseString.Length > 0 && format.BaseString[format.StartIndex] == ':') return false;
-            
+            if (format == null) return false;
+
             // Extract the plural words from the format string:
             var pluralWords = format.Split(SplitChar);
             // This extension requires at least two plural words:


### PR DESCRIPTION
An implementation of a magic leading colon in order to identify whether `ConditionalFormatter` or `PluralLocalizationFormatter` should be invoked, was removed.

**Reasoning:**
This is an undocumented and unnecessary code smell. 
Adding the formatter name in the format string fulfills the same target.
