### PR TITLE
Pr choose fmt options case sensitivity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -582,6 +582,15 @@ _ = smart.Format({0:cond:|No|\t|Yes|}", 1);
 // Result: "|Yes|"
 ```
 
+c) ChooseFormatter [#253](https://github.com/axuno/SmartFormat/pull/253)
+
+    Modified `ChooseFormatter` case-sensitivity for option strings. This modification is compatible with v2.
+
+    * `bool` and `null` as string: always case-insensitive
+    * using `SmartSettings.CaseSensitivity` unless overridden with `ChooseFormatter.CaseSensitivity`
+    * option strings comparison is culture-aware
+
+
 v2.7.2
 ===
 * **Fixed**: `ConditionalFormatter` processes unsigned numbers in arguments correctly.

--- a/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
@@ -44,15 +44,22 @@ namespace SmartFormat.Tests.Extensions
             Assert.That(result, Is.EqualTo("|two|"));
         }
 
-        [TestCase("{0:choose(true|True):one|two|default}", true, "two")]
-        [TestCase("{0:choose(true|TRUE):one|two|default}", true, "default")]
-        [TestCase("{0:choose(string|String):one|two|default}", "String", "two")]
-        [TestCase("{0:choose(string|STRING):one|two|default}", "String", "default")]
-        [TestCase("{0:choose(ignore|Ignore):one|two|default}", SmartFormat.Core.Settings.FormatErrorAction.Ignore, "two")]
-        [TestCase("{0:choose(ignore|IGNORE):one|two|default}", SmartFormat.Core.Settings.FormatErrorAction.Ignore, "default")]
-        public void Choose_should_be_case_sensitive(string format, object arg0, string expectedResult)
+        // bool and null args: always case-insensitive
+        [TestCase("{0:choose(true|false):one|two|default}", false, true, "one")]
+        [TestCase("{0:choose(True|FALSE):one|two|default}", false, false, "two")]
+        [TestCase("{0:choose(null):is null|default}", false, default, "is null")]
+        [TestCase("{0:choose(NULL):is null|default}", false, default, "is null")]
+        // strings
+        [TestCase("{0:choose(string|String):one|two|default}", true, "String", "two")]
+        [TestCase("{0:choose(string|STRING):one|two|default}", true, "String", "default")]
+        // Enum
+        [TestCase("{0:choose(ignore|Ignore):one|two|default}", true, FormatErrorAction.Ignore, "two")]
+        [TestCase("{0:choose(ignore|IGNORE):one|two|default}", true, FormatErrorAction.Ignore, "default")]
+        public void Choose_should_be_case_sensitive(string format, bool caseSensitive, object arg0, string expectedResult)
         {
             var smart = Smart.CreateDefaultSmartFormat();
+            smart.GetFormatterExtension<ChooseFormatter>()!.CaseSensitivity =
+                caseSensitive ? CaseSensitivityType.CaseSensitive : CaseSensitivityType.CaseInsensitive;
             Assert.AreEqual(expectedResult, smart.Format(format, arg0));
         }
         

--- a/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
@@ -140,5 +140,19 @@ namespace SmartFormat.Tests.Extensions
 
             Assert.That(result, Is.EqualTo(expected));
         }
+
+        [Test, Description("Case-insensitive option string comparison")]
+        public void Choose_Should_Use_CultureInfo_For_Option_Strings()
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            var smart = Smart.CreateDefaultSmartFormat();
+            smart.GetFormatterExtension<ChooseFormatter>()!.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
+
+            var result1 = smart.Format(CultureInfo.GetCultureInfo("de"), "{0:choose(ä|ü):umlautA|umlautU}", "Ä");
+            var result2 = smart.Format(CultureInfo.GetCultureInfo("de"), "{0:choose(ä|ü):umlautA|umlautU}", "ä");
+
+            Assert.That(result1, Is.EqualTo("umlautA"));
+            Assert.That(result2, Is.EqualTo("umlautA"));
+        }
     }
 }

--- a/src/SmartFormat.Tests/Extensions/LocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/LocalizationFormatterTests.cs
@@ -111,7 +111,7 @@ namespace SmartFormat.Tests.Extensions
             _ = smart.Format("{:L(es):WeTranslateText}");
             var result = smart.Format("{:L(es):WeTranslateText}");
 
-            Assert.That(locFormatter!.LocalizedFormatCache!.Keys.Contains(result), Is.True);
+            Assert.That(locFormatter!.LocalizedFormatCache!.ContainsKey(result), Is.True);
         }
 
         [TestCase("{:L():WeTranslateText}", "Traducimos el texto", "es")]

--- a/src/SmartFormat.Tests/Extensions/PersistentVariableSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PersistentVariableSourceTests.cs
@@ -38,7 +38,7 @@ namespace SmartFormat.Tests.Extensions
             Assert.That(pvs[groupName1], Is.EqualTo(vg1));
             Assert.That(pvs[groupName2], Is.EqualTo(vg2));
             Assert.That(pvs.Keys.Count, Is.EqualTo(2));
-            Assert.That(pvs.Keys.Contains(groupName1));
+            Assert.That(pvs.ContainsKey(groupName1));
             Assert.That(pvs.Values.Count, Is.EqualTo(2));
             Assert.That(pvs.Values.Contains(vg1));
             Assert.That(pvs.Values.Contains(vg2));

--- a/src/SmartFormat.Tests/Extensions/VariablesGroupTests.cs
+++ b/src/SmartFormat.Tests/Extensions/VariablesGroupTests.cs
@@ -42,7 +42,7 @@ namespace SmartFormat.Tests.Extensions
             Assert.That((int) vg[var1Name].GetValue()!, Is.EqualTo(1234));
             Assert.That((string) vg[var2Name].GetValue()!, Is.EqualTo("theValue"));
             Assert.That(vg.Keys.Count, Is.EqualTo(3));
-            Assert.That(vg.Keys.Contains(var1Name));
+            Assert.That(vg.ContainsKey(var1Name));
             Assert.That(vg.Values.Count, Is.EqualTo(3));
             Assert.That(vg.Values.Contains(var1));
             Assert.That(vg.Values.Contains(var2));


### PR DESCRIPTION
### ChooseFormatter

Modified `ChooseFormatter` case-sensitivity for option strings. This modification is compatible with v2.

* `bool` and `null` as string: always case-insensitive
* using `SmartSettings.CaseSensitivity` unless overridden with `ChooseFormatter.CaseSensitivity`
* option strings comparison is culture-aware (using `CultureInfo` arg to `Smart.Format(...)` or `CurrentUICulture`