### PR TITLE
KeyValuePairSource can process nullable notation

### DIFF
--- a/src/SmartFormat.Tests/Extensions/KeyValuePairSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/KeyValuePairSourceTests.cs
@@ -46,5 +46,25 @@ namespace SmartFormat.Tests.Extensions
                 }, Throws.Nothing);
             Assert.That(result, Is.EqualTo(expected));
         }
+
+        [TestCase(null, "")]
+        public void Call_With_KeyValuePair_Nullable(string? theValue, string expected)
+        {
+            // KeyValuePairSource can process nullable notation
+            // This is only required, if it is the only ISource
+            var smart = new SmartFormatter();
+            smart.AddExtensions(new KeyValuePairSource());
+            smart.AddExtensions(new DefaultFormatter());
+
+            var result = string.Empty;
+            Assert.That(
+                code: () =>
+                {
+                    // Nullable Notation:
+                    // If placeholder is null, Anything should not get evaluated
+                    result = smart.Format("{placeholder?.AnyThing}", new KeyValuePair<string, object?>("placeholder", theValue));
+                }, Throws.Nothing);
+            Assert.That(result, Is.EqualTo(expected));
+        }
     }
 }

--- a/src/SmartFormat/Extensions/KeyValuePairSource.cs
+++ b/src/SmartFormat/Extensions/KeyValuePairSource.cs
@@ -22,6 +22,12 @@ namespace SmartFormat.Extensions
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
+            if (selectorInfo.CurrentValue is null && HasNullableOperator(selectorInfo))
+            {
+                selectorInfo.Result = null;
+                return true;
+            }
+
             switch (selectorInfo.CurrentValue)
             {
                 case null:

--- a/src/SmartFormat/Extensions/WellKnownExtensionTypes.cs
+++ b/src/SmartFormat/Extensions/WellKnownExtensionTypes.cs
@@ -22,7 +22,7 @@ namespace SmartFormat.Extensions
         /// <summary>
         /// Well-known <see cref="ISource"/> implementations in the sequence how they should (not must!) be invoked.
         /// </summary>
-        public static Dictionary<string, int> Sources { get; } = new(StringComparer.InvariantCulture) {
+        public static Dictionary<string, int> Sources { get; } = new(StringComparer.Ordinal) {
             { "SmartFormat.Extensions.GlobalVariablesSource", 1000 },
             { "SmartFormat.Extensions.PersistentVariablesSource", 2000 },
             { "SmartFormat.Extensions.StringSource", 3000 },
@@ -41,7 +41,7 @@ namespace SmartFormat.Extensions
         /// <summary>
         /// Well-known <see cref="IFormatter"/> implementations in the sequence how they should (not must!) be invoked.
         /// </summary>
-        public static Dictionary<string, int> Formatters { get; } = new(StringComparer.InvariantCulture)
+        public static Dictionary<string, int> Formatters { get; } = new(StringComparer.Ordinal)
         {
             { "SmartFormat.Extensions.ListFormatter", 1000 },
             { "SmartFormat.Extensions.PluralLocalizationFormatter", 2000 },


### PR DESCRIPTION
KeyValuePairSource can process Nullable Notation
This is only required, if it is the only registered `ISource`