### PR TITLE
PersistentVariablesSource can process nullable operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -166,7 +166,7 @@ var pvs = new PersistentVariablesSource
     { "global", varGroup }
 };
 // Best to put it to the top of source extensions
-smart.AddExtensions(0, pvs);
+smart.InsertExtension(0, pvs);
 
 // Note: We don't need args to the formatter for PersistentVariablesSource variables
 _ = smart.Format(CultureInfo.InvariantCulture,

--- a/src/SmartFormat.Extensions.Newtonsoft.Json/NewtonsoftJsonSource.cs
+++ b/src/SmartFormat.Extensions.Newtonsoft.Json/NewtonsoftJsonSource.cs
@@ -26,12 +26,8 @@ namespace SmartFormat.Extensions
                 JValue jsonValue => jsonValue.Value,
                 _ => selectorInfo.CurrentValue
             };
-            
-            if (current is null && HasNullableOperator(selectorInfo))
-            {
-                selectorInfo.Result = null;
-                return true;
-            }
+
+            if (TrySetResultForNullableOperator(selectorInfo)) return true;
 
             if (current is null) return false;
 

--- a/src/SmartFormat.Extensions.System.Text.Json/SystemTextJsonSource.cs
+++ b/src/SmartFormat.Extensions.System.Text.Json/SystemTextJsonSource.cs
@@ -26,11 +26,7 @@ namespace SmartFormat.Extensions
                 _ => selectorInfo.CurrentValue
             };
             
-            if (current is null && HasNullableOperator(selectorInfo))
-            {
-                selectorInfo.Result = null;
-                return true;
-            }
+            if (TrySetResultForNullableOperator(selectorInfo)) return true;
 
             if (current is not JsonElement element) return false;
 

--- a/src/SmartFormat.Tests/Extensions/PersistentVariableSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PersistentVariableSourceTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
@@ -226,6 +225,31 @@ namespace SmartFormat.Tests.Extensions
 
             Assert.That(pvs.Name, Is.EqualTo("theName"));
             Assert.That(pvs.Group.ContainsKey("varName"), Is.True);
+        }
+
+        [TestCase("not-null", "not-null")]
+        [TestCase(null, "")]
+        public void Should_Handle_null_for_Nullable(object? valueToUse, string expected)
+        {
+            if (valueToUse is "not-null")
+                valueToUse = new KeyValuePair<string, object?>("Anything", "not-null");
+
+            // The group with just one nullable variable
+            var varGroup = new VariablesGroup { { "NullableVar", new ObjectVariable(valueToUse) } };
+
+            var smart = new SmartFormatter();
+            smart.FormatterExtensions.Add(new DefaultFormatter());
+            var pvs = new PersistentVariablesSource
+            {
+                // top container's name
+                { "Global", varGroup }
+            };
+            
+            smart.AddExtensions(new KeyValuePairSource());
+            smart.InsertExtension(0, pvs);
+
+            var result = smart.Format("{Global.NullableVar?.Anything}");
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/SmartFormat/Core/Sources/Source.cs
+++ b/src/SmartFormat/Core/Sources/Source.cs
@@ -49,11 +49,36 @@ namespace SmartFormat.Core.Extensions
         /// <remarks>
         /// The nullable operator '?' can be followed by a dot (like '?.') or a square brace (like '.[')
         /// </remarks>
-        protected virtual bool HasNullableOperator(ISelectorInfo selectorInfo)
+        private bool HasNullableOperator(ISelectorInfo selectorInfo)
         {
             return _smartSettings != null && selectorInfo.Placeholder != null &&
                    selectorInfo.Placeholder.Selectors.Any(s =>
                        s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator);
+        }
+
+        /// <summary>
+        /// If any of the <see cref="Placeholder"/>'s <see cref="Placeholder.Selectors"/> has
+        /// nullable <c>?</c> as their first operator, and <see cref="ISelectorInfo.CurrentValue"/>
+        /// is <see langword="null"/>, <see cref="ISelectorInfo.Result"/> will be set to <see langword="null"/>.
+        /// </summary>
+        /// <param name="selectorInfo"></param>
+        /// <returns>
+        /// <see langword="true"/>, if any of the <see cref="Placeholder"/>'s
+        /// <see cref="Placeholder.Selectors"/> has  nullable <c>?</c> as their first
+        /// operator, and <see cref="ISelectorInfo.CurrentValue"/> is <see langword="null"/>.
+        /// </returns>
+        /// <remarks>
+        /// The nullable operator '?' can be followed by a dot (like '?.') or a square brace (like '.[')
+        /// </remarks>
+        protected virtual bool TrySetResultForNullableOperator(ISelectorInfo selectorInfo)
+        {
+            if (HasNullableOperator(selectorInfo) && selectorInfo.CurrentValue is null)
+            {
+                selectorInfo.Result = null;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/SmartFormat/Extensions/DictionarySource.cs
+++ b/src/SmartFormat/Extensions/DictionarySource.cs
@@ -19,11 +19,7 @@ namespace SmartFormat.Extensions
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
             var current = selectorInfo.CurrentValue;
-            if (current is null && HasNullableOperator(selectorInfo))
-            {
-                selectorInfo.Result = null;
-                return true;
-            }
+            if (TrySetResultForNullableOperator(selectorInfo)) return true;
             
             if (current is null) return false;
 

--- a/src/SmartFormat/Extensions/KeyValuePairSource.cs
+++ b/src/SmartFormat/Extensions/KeyValuePairSource.cs
@@ -22,11 +22,7 @@ namespace SmartFormat.Extensions
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
-            if (selectorInfo.CurrentValue is null && HasNullableOperator(selectorInfo))
-            {
-                selectorInfo.Result = null;
-                return true;
-            }
+            if (TrySetResultForNullableOperator(selectorInfo)) return true;
 
             switch (selectorInfo.CurrentValue)
             {

--- a/src/SmartFormat/Extensions/StringSource.cs
+++ b/src/SmartFormat/Extensions/StringSource.cs
@@ -71,11 +71,7 @@ namespace SmartFormat.Extensions
         /// <inheritdoc />
         public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
         {
-            if (selectorInfo.CurrentValue is null && HasNullableOperator(selectorInfo))
-            {
-                selectorInfo.Result = null;
-                return true;
-            }
+            if (TrySetResultForNullableOperator(selectorInfo)) return true;
 
             if (selectorInfo.CurrentValue is not string currentValue) return false;
             var selector = selectorInfo.SelectorText;


### PR DESCRIPTION
1. `PersistentVariablesSource` can process `nullable` operator `?.`
2. Added method Source.TrySetResultForNullableOperator(ISelectorInfo selectorInfo)
   * Call this method from all `ISource`s except `DefaultSource`