### PR TITLE
Feature: Nested formatting inside of List spacers 

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -113,6 +113,16 @@ namespace SmartFormat.Tests.Extensions
 
         }
 
+        [Test]
+        public void NestedFormatSpacers()
+        {
+            var smart = Smart.CreateDefaultSmartFormat();
+            var names = new[] { "John", "Mary", "Amy" };
+
+            Assert.AreEqual("John, Mary and Amy", smart.Format("{0:list:{}|{1} | {2} }", names, ",", "and"));
+            Assert.AreEqual("John, Mary nor Amy", smart.Format("{0.Names:list:{}|, | {0.Not:nor|or} }", new { Names = names, Not = true }));
+        }
+
         [TestCase("{0:list:{}-|}", "A-B-C-D-E-")]
         [TestCase("{0:list:{}|-}", "A-B-C-D-E")]
         [TestCase("{0:list:{}|-|+}", "A-B-C-D+E")]

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -120,7 +120,7 @@ namespace SmartFormat.Tests.Extensions
             var names = new[] { "John", "Mary", "Amy" };
 
             Assert.AreEqual("John, Mary and Amy", smart.Format("{0:list:{}|{1} | {2} }", names, ",", "and"));
-            Assert.AreEqual("John, Mary nor Amy", smart.Format("{0.Names:list:{}|, | {0.Not:nor|or} }", new { Names = names, Not = true }));
+            Assert.AreEqual("John, Mary nor Amy", smart.Format("{Names:list:{}|, | {Not:nor|or} }", new { Names = names, Not = true }));
         }
 
         [TestCase("{0:list:{}-|}", "A-B-C-D-E-")]

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using SmartFormat.Core.Extensions;
-using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Parsing;
 using SmartFormat.Core.Settings;
 using SmartFormat.Pooling.SmartPools;

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using SmartFormat.Core.Extensions;
+using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Parsing;
 using SmartFormat.Core.Settings;
 using SmartFormat.Pooling.SmartPools;
@@ -189,9 +190,9 @@ namespace SmartFormat.Extensions
             // itemFormat|spacer|lastSpacer
             // itemFormat|spacer|lastSpacer|twoSpacer
             var itemFormat = parameters[0];
-            var spacer = parameters.Count >= 2 ? parameters[1].GetLiteralText() : string.Empty;
-            var lastSpacer = parameters.Count >= 3 ? parameters[2].GetLiteralText() : spacer;
-            var twoSpacer = parameters.Count >= 4 ? parameters[3].GetLiteralText() : lastSpacer;
+            var spacer = parameters.Count >= 2 ? parameters[1] : null;
+            var lastSpacer = parameters.Count >= 3 ? parameters[2] : spacer;
+            var twoSpacer = parameters.Count >= 4 ? parameters[3] : lastSpacer;
             
             if (!itemFormat.HasNested)
             {
@@ -241,15 +242,15 @@ namespace SmartFormat.Extensions
                 }
                 else if (CollectionIndex < items.Count - 1)
                 {
-                    spacerFormattingInfo.Write(spacer);
+                    WriteSpacer(spacerFormattingInfo, spacer, item);
                 }
                 else if (CollectionIndex == 1)
                 {
-                    spacerFormattingInfo.Write(twoSpacer);
+                    WriteSpacer(spacerFormattingInfo, twoSpacer, item);
                 }
                 else
                 {
-                    spacerFormattingInfo.Write(lastSpacer);
+                    WriteSpacer(spacerFormattingInfo, lastSpacer, item);
                 }
 
                 // Output the nested format for this item:
@@ -266,6 +267,14 @@ namespace SmartFormat.Extensions
             parameters.Clear();
 
             return true;
+        }
+
+        static void WriteSpacer(FormattingInfo formattingInfo, Format? spacer, object item)
+        {
+            if (spacer == null)
+                formattingInfo.Write(string.Empty);
+            else
+                formattingInfo.FormatAsChild(spacer, item);
         }
 
         /// <summary>

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -230,6 +230,18 @@ namespace SmartFormat.Extensions
                 .Initialize(null, formattingInfo.FormatDetails, format, null);
             spacerFormattingInfo.Alignment = 0;
 
+            // Note:
+            // Give spacers the data context of the root parent.
+            // formattingInfo.CurrentValue from the argument to
+            // TryEvaluateFormat(IFormattingInfo formattingInfo) only contains the list elements.
+            var rootParent = (formattingInfo as Core.Formatting.FormattingInfo);
+            do
+            {
+                rootParent = rootParent?.Parent;
+            } while (rootParent?.Parent != null);
+
+            var rootParentValue = rootParent?.CurrentValue;
+
             foreach (var item in items)
             {
                 CollectionIndex += 1; // Keep track of the index
@@ -241,15 +253,15 @@ namespace SmartFormat.Extensions
                 }
                 else if (CollectionIndex < items.Count - 1)
                 {
-                    spacerFormattingInfo.FormatAsChild(spacer, item);
+                    WriteSpacer(spacerFormattingInfo, spacer, rootParentValue);
                 }
                 else if (CollectionIndex == 1)
                 {
-                    spacerFormattingInfo.FormatAsChild(twoSpacer, item);
+                    WriteSpacer(spacerFormattingInfo, twoSpacer, rootParentValue);
                 }
                 else
                 {
-                    spacerFormattingInfo.FormatAsChild(lastSpacer, item);
+                    WriteSpacer(spacerFormattingInfo, lastSpacer, rootParentValue);
                 }
 
                 // Output the nested format for this item:
@@ -266,6 +278,14 @@ namespace SmartFormat.Extensions
             parameters.Clear();
 
             return true;
+        }
+
+        private static void WriteSpacer(IFormattingInfo formattingInfo, Format spacer, object? value)
+        {
+            if (spacer.HasNested)
+                formattingInfo.FormatAsChild(spacer, value);
+            else
+                formattingInfo.Write(spacer.GetLiteralText());
         }
 
         /// <summary>

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -190,7 +190,7 @@ namespace SmartFormat.Extensions
             // itemFormat|spacer|lastSpacer
             // itemFormat|spacer|lastSpacer|twoSpacer
             var itemFormat = parameters[0];
-            var spacer = parameters.Count >= 2 ? parameters[1] : null;
+            var spacer = parameters[1];
             var lastSpacer = parameters.Count >= 3 ? parameters[2] : spacer;
             var twoSpacer = parameters.Count >= 4 ? parameters[3] : lastSpacer;
             
@@ -242,15 +242,15 @@ namespace SmartFormat.Extensions
                 }
                 else if (CollectionIndex < items.Count - 1)
                 {
-                    WriteSpacer(spacerFormattingInfo, spacer, item);
+                    spacerFormattingInfo.FormatAsChild(spacer, item);
                 }
                 else if (CollectionIndex == 1)
                 {
-                    WriteSpacer(spacerFormattingInfo, twoSpacer, item);
+                    spacerFormattingInfo.FormatAsChild(twoSpacer, item);
                 }
                 else
                 {
-                    WriteSpacer(spacerFormattingInfo, lastSpacer, item);
+                    spacerFormattingInfo.FormatAsChild(lastSpacer, item);
                 }
 
                 // Output the nested format for this item:
@@ -267,14 +267,6 @@ namespace SmartFormat.Extensions
             parameters.Clear();
 
             return true;
-        }
-
-        static void WriteSpacer(FormattingInfo formattingInfo, Format? spacer, object item)
-        {
-            if (spacer == null)
-                formattingInfo.Write(string.Empty);
-            else
-                formattingInfo.FormatAsChild(spacer, item);
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed in https://github.com/axuno/SmartFormat/issues/279

This adds support for using formatting on all the spacers of a list.
I removed the null spacer as from what I can see it would never happen because `parameters.Count` will always be at least 2, we exit the code if its not earlier on.