### PR TITLE
Features for upcoming v3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,45 @@
 Latest Changes
 ====
 
+v3.1.0
+===
+
+This is a feature update, that is released upon feedback from the community.
+
+### Thread-safe Mode
+
+Thread-safe mode is now enabled by default:
+`SmartSettings.IsThreadSafeMode == true`.<br/>
+This has no impact on the API.
+
+In case *SmartFormat* is *exclusively* utilized in a single-threaded context, `SmartSettings.IsThreadSafeMode=false` should be considered for enhanced performance.
+
+### Static `Smart` Methods for Formatting
+
+Static `Smart` methods like Smart.Format(*format*, *args*) can now be called in an `async` / multi-threaded context.
+
+The `SmartFormatter` instance returned by `Smart.Default` is flagged with the `ThreadStatic` attribute.
+
+### `ListFormatter` may have Placeholders in "spacers"
+
+Thanks to **[karljj1](https://github.com/axuno/SmartFormat/commits?author=karljj1)** for the PR.
+
+Before *v3.1.0* the format options for `ListFormatter` could only contain literal text. Now `Placeholder`s are allowed.
+
+#### Example:
+
+```CSharp
+var args = new {
+    Names = new[] { "John", "Mary", "Amy" },
+    IsAnd = true, // true or false
+    Split = ", "  // comma and space as list separator
+};
+_ = Smart.Format("{Names:list:{}|{Split}| {IsAnd:and|nor} }", args);
+// Output for "IsAnd=true":  "John, Mary and Amy"
+// Output for "IsAnd=false": "John, Mary nor Amy"
+```
+<br/>
+
 v3.0.0
 ===
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@
 [![NuGet](https://img.shields.io/nuget/v/SmartFormat.svg)](https://www.nuget.org/packages/SmartFormat/) Install the **core** NuGet package
 
 [![Docs](https://img.shields.io/badge/docs-up%20to%20date-brightgreen.svg)](https://github.com/axuno/SmartFormat/wiki)
-Have a look at the [SmartFormat Wiki](https://github.com/axuno/SmartFormat/wiki)<br/>
-**Using `async` / multithreading? [Follow this](https://github.com/axuno/SmartFormat/wiki/Async-and-Thread-Safety).**
+Have a look at the [SmartFormat Wiki](https://github.com/axuno/SmartFormat/wiki)
 
 See the [changelog](CHANGES.md) for changes.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@
 * .Net Standard 2.1 and later for best optimizations
  
 ### Get started
-[![NuGet](https://img.shields.io/nuget/v/SmartFormat.Net.svg)](https://www.nuget.org/packages/SmartFormat.Net/) Install the **full** NuGet package *-or-*
+[![NuGet](https://img.shields.io/nuget/v/SmartFormat.svg)](https://www.nuget.org/packages/SmartFormat.Net/) Install the **full** NuGet package *-or-*
 
 [![NuGet](https://img.shields.io/nuget/v/SmartFormat.svg)](https://www.nuget.org/packages/SmartFormat/) Install the **core** NuGet package
 
-[![Docs](https://img.shields.io/badge/docs-up%20to%20date-brightgreen.svg)](https://github.com/axuno/SmartFormat.Net/wiki)
-Have a look at the [SmartFormat.Net Wiki](https://github.com/axuno/SmartFormat.Net/wiki)
+[![Docs](https://img.shields.io/badge/docs-up%20to%20date-brightgreen.svg)](https://github.com/axuno/SmartFormat/wiki)
+Have a look at the [SmartFormat Wiki](https://github.com/axuno/SmartFormat/wiki)<br/>
+**Using `async` / multithreading? [Follow this](https://github.com/axuno/SmartFormat/wiki/Async-and-Thread-Safety).**
 
 See the [changelog](CHANGES.md) for changes.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,11 +8,13 @@
         <Copyright>Copyright 2011-$(CurrentYear) SmartFormat Project</Copyright>
         <RepositoryUrl>https://github.com/axuno/SmartFormat.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>3.0.0</Version>
-        <FileVersion>3.0.0</FileVersion>
+        <Version>3.1.0</Version>
+        <FileVersion>3.1.0</FileVersion>
         <AssemblyVersion>3.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisMode>Default</AnalysisMode>
+        <AnalysisModeSecurity>All</AnalysisModeSecurity>
         <AnalysisLevel>latest</AnalysisLevel>
         <Features>strict</Features>
     </PropertyGroup>

--- a/src/SmartFormat.Tests/Core/FormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatterTests.cs
@@ -323,7 +323,7 @@ namespace SmartFormat.Tests.Core
                     results.TryAdd(i, Smart.Format("{0}", i));
                     Interlocked.Increment(ref resultCounter);
                 }), Throws.Nothing);
-            Assert.That(threadIds.Count, Is.AtLeast(4)); // otherwise the test is not significant
+            Assert.That(threadIds.Count, Is.AtLeast(2)); // otherwise the test is not significant
             Assert.That(Smart.CreateDefaultSmartFormat().GetFormatterExtension<ChooseFormatter>(), Is.Not.Null);
             Assert.That(threadIds.Count, Is.EqualTo(formatterInstancesCounter));
             Assert.That(results.Count, Is.EqualTo(resultCounter));

--- a/src/SmartFormat.Tests/Core/FormatterTests.cs
+++ b/src/SmartFormat.Tests/Core/FormatterTests.cs
@@ -317,7 +317,7 @@ namespace SmartFormat.Tests.Core
                     }
 
                     // register unique thread ids
-                    threadIds.TryAdd(Thread.CurrentThread.ManagedThreadId, Thread.CurrentThread.ManagedThreadId);
+                    threadIds.TryAdd(Environment.CurrentManagedThreadId, Environment.CurrentManagedThreadId);
                     // Smart.Default is a thread-static instance of the SmartFormatter,
                     // which is used here
                     results.TryAdd(i, Smart.Format("{0}", i));

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -113,14 +113,19 @@ namespace SmartFormat.Tests.Extensions
 
         }
 
-        [Test]
-        public void NestedFormatSpacers()
+        [TestCase(true, ", ", "John, Mary and Amy")]
+        [TestCase(false, ", ", "John, Mary nor Amy")]
+        public void NestedFormatSpacers(bool isAnd, string split, string expected)
         {
             var smart = Smart.CreateDefaultSmartFormat();
-            var names = new[] { "John", "Mary", "Amy" };
+            var args = new {
+                Names = new[] { "John", "Mary", "Amy" },
+                IsAnd = isAnd, // true or false
+                Split = split // comma as list separator
+            };
 
-            Assert.AreEqual("John, Mary and Amy", smart.Format("{0:list:{}|{1} | {2} }", names, ",", "and"));
-            Assert.AreEqual("John, Mary nor Amy", smart.Format("{Names:list:{}|, | {Not:nor|or} }", new { Names = names, Not = true }));
+            Assert.AreEqual(expected, smart.Format("{0:list:{}|{1}| {2} }", args.Names, args.Split, args.IsAnd ? "and" : "nor"));
+            Assert.AreEqual(expected, smart.Format("{Names:list:{}|{Split}| {IsAnd:and|nor} }", args));
         }
 
         [TestCase("{0:list:{}-|}", "A-B-C-D-E-")]

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -4,7 +4,7 @@
 		<Description>Unit tests for SmartFormat</Description>
 		<AssemblyTitle>SmartFormat.Test</AssemblyTitle>
 		<Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>net462;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net5.0</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<AssemblyName>SmartFormat.Tests</AssemblyName>

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -4,7 +4,7 @@
 		<Description>Unit tests for SmartFormat</Description>
 		<AssemblyTitle>SmartFormat.Test</AssemblyTitle>
 		<Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net5.0</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<AssemblyName>SmartFormat.Tests</AssemblyName>

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -4,7 +4,7 @@
 		<Description>Unit tests for SmartFormat</Description>
 		<AssemblyTitle>SmartFormat.Test</AssemblyTitle>
 		<Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>net462;net5.0</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp6.0</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<AssemblyName>SmartFormat.Tests</AssemblyName>

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -4,7 +4,7 @@
 		<Description>Unit tests for SmartFormat</Description>
 		<AssemblyTitle>SmartFormat.Test</AssemblyTitle>
 		<Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>net462;net5.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<AssemblyName>SmartFormat.Tests</AssemblyName>

--- a/src/SmartFormat/Core/Settings/SmartSettings.cs
+++ b/src/SmartFormat/Core/Settings/SmartSettings.cs
@@ -28,9 +28,9 @@ namespace SmartFormat.Core.Settings
         /// Thread safety is relevant for global caching, lists and object pools,
         /// which can be filled from different threads concurrently.
         /// <para><see langword="true"/> does <b>not</b> guarantee thread safety of all classes.</para>
-        /// Default is <see langword="false"/>.
+        /// Default is <see langword="true"/>.
         /// </summary>
-        public static bool IsThreadSafeMode { get; set; } = false;
+        public static bool IsThreadSafeMode { get; set; } = true;
 
         /// <summary>
         /// Uses <c>string.Format</c>-compatible escaping of curly braces, {{ and }},

--- a/src/SmartFormat/Pooling/PoolRegistry.cs
+++ b/src/SmartFormat/Pooling/PoolRegistry.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using SmartFormat.Pooling.SpecializedPools;
 
 namespace SmartFormat.Pooling
 {

--- a/src/SmartFormat/Pooling/SpecializedPools/SpecializedPoolAbstract.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/SpecializedPoolAbstract.cs
@@ -35,6 +35,11 @@ namespace SmartFormat.Pooling.SpecializedPools
         }
 
         /// <summary>
+        /// Gets whether the pool is running in thread-safe mode.
+        /// </summary>
+        public bool IsThreadSafeMode => _isThreadSafeMode;
+
+        /// <summary>
         /// Disposes the current instance of the <see cref="ObjectPool{T}"/> and
         /// creates a new one, applying the current <see cref="PoolSettings"/> and <see cref="PoolPolicy{T}"/>.
         /// </summary>

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -454,7 +454,7 @@ namespace SmartFormat
         public void FormatInto(IOutput output, IFormatProvider? provider, string format, IList<object?> args)
         {
             var formatParsed = Parser.ParseFormat(format);
-            FormatInto(output, null, formatParsed, args);
+            FormatInto(output, provider, formatParsed, args);
             FormatPool.Instance.Return(formatParsed); // The parser gets the Format from the pool
         }
 


### PR DESCRIPTION
### Thread-safe Mode

Thread-safe mode is now enabled by default:
`SmartSettings.IsThreadSafeMode == true`.<br/>
This has no impact on the API.

In case *SmartFormat* is *exclusively* utilized in a single-threaded context, `SmartSettings.IsThreadSafeMode=false` should be considered for enhanced performance.

### Static `Smart` Methods for Formatting

Static `Smart` methods like Smart.Format(*format*, *args*) can now be called in an `async` / multi-threaded context.

The `SmartFormatter` instance returned by `Smart.Default` is flagged with the `ThreadStatic` attribute.

### `ListFormatter` may have Placeholders in "spacers"

Thanks to **[karljj1](https://github.com/axuno/SmartFormat/commits?author=karljj1)** for the PR.

Before *v3.1.0* the format options for `ListFormatter` could only contain literal text. Now `Placeholder`s are allowed.

#### Example:

```CSharp
var args = new {
    Names = new[] { "John", "Mary", "Amy" },
    IsAnd = true, // true or false
    Split = ", "  // comma and space as list separator
};
_ = Smart.Format("{Names:list:{}|{Split}| {IsAnd:and|nor} }", args);
// Output for "IsAnd=true":  "John, Mary and Amy"
// Output for "IsAnd=false": "John, Mary nor Amy"
```
