### PR TITLE
Refactor suggestions

### DIFF
--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptions.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptions.cs
@@ -131,17 +131,12 @@ namespace SmartFormat.Extensions.Time.Utilities
         /// </para>
         /// </summary>
         RangeWeeks = 0x2000,
-
-        /// <summary>(for internal use only)</summary>
-        _Abbreviate = Abbreviate | AbbreviateOff,
-
-        /// <summary>(for internal use only)</summary>
-        _LessThan = LessThan | LessThanOff,
-
-        /// <summary>(for internal use only)</summary>
-        _Truncate = TruncateShortest | TruncateAuto | TruncateFill | TruncateFull,
-
-        /// <summary>(for internal use only)</summary>
-        _Range = RangeMilliSeconds | RangeSeconds | RangeMinutes | RangeHours | RangeDays | RangeWeeks
     }
-}
+
+    internal static class TimeSpanFormatOptionsPresets
+    {
+        public const TimeSpanFormatOptions Abbreviate = TimeSpanFormatOptions.Abbreviate | TimeSpanFormatOptions.AbbreviateOff;
+        public const TimeSpanFormatOptions LessThan = TimeSpanFormatOptions.LessThan | TimeSpanFormatOptions.LessThanOff;
+        public const TimeSpanFormatOptions Truncate = TimeSpanFormatOptions.TruncateShortest | TimeSpanFormatOptions.TruncateAuto | TimeSpanFormatOptions.TruncateFill | TimeSpanFormatOptions.TruncateFull;
+        public const TimeSpanFormatOptions Range = TimeSpanFormatOptions.RangeMilliSeconds | TimeSpanFormatOptions.RangeSeconds | TimeSpanFormatOptions.RangeMinutes | TimeSpanFormatOptions.RangeHours | TimeSpanFormatOptions.RangeDays | TimeSpanFormatOptions.RangeWeeks;
+    }

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptions.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptions.cs
@@ -140,3 +140,4 @@ namespace SmartFormat.Extensions.Time.Utilities
         public const TimeSpanFormatOptions Truncate = TimeSpanFormatOptions.TruncateShortest | TimeSpanFormatOptions.TruncateAuto | TimeSpanFormatOptions.TruncateFill | TimeSpanFormatOptions.TruncateFull;
         public const TimeSpanFormatOptions Range = TimeSpanFormatOptions.RangeMilliSeconds | TimeSpanFormatOptions.RangeSeconds | TimeSpanFormatOptions.RangeMinutes | TimeSpanFormatOptions.RangeHours | TimeSpanFormatOptions.RangeDays | TimeSpanFormatOptions.RangeWeeks;
     }
+}

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptionsConverter.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanFormatOptionsConverter.cs
@@ -18,10 +18,10 @@ namespace SmartFormat.Extensions.Time.Utilities
         {
             var masks = new[]
             {
-                TimeSpanFormatOptions._Abbreviate,
-                TimeSpanFormatOptions._LessThan,
-                TimeSpanFormatOptions._Range,
-                TimeSpanFormatOptions._Truncate
+                TimeSpanFormatOptionsPresets.Abbreviate,
+                TimeSpanFormatOptionsPresets.LessThan,
+                TimeSpanFormatOptionsPresets.Range,
+                TimeSpanFormatOptionsPresets.Truncate
             };
             foreach (var mask in masks)
                 if ((left & mask) == 0)

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
@@ -55,11 +55,11 @@ namespace SmartFormat.Extensions.Time.Utilities
             options = options.Merge(DefaultFormatOptions).Merge(AbsoluteDefaults);
             
             // Extract the individual options:
-            var rangeMax = options.Mask(TimeSpanFormatOptions._Range).AllFlags().Last();
-            _rangeMin = options.Mask(TimeSpanFormatOptions._Range).AllFlags().First();
-            _truncate = options.Mask(TimeSpanFormatOptions._Truncate).AllFlags().First();
-            _lessThan = options.Mask(TimeSpanFormatOptions._LessThan) != TimeSpanFormatOptions.LessThanOff;
-            _abbreviate = options.Mask(TimeSpanFormatOptions._Abbreviate) != TimeSpanFormatOptions.AbbreviateOff;
+            var rangeMax = options.Mask(TimeSpanFormatOptionsPresets.Range).AllFlags().Last();
+            _rangeMin = options.Mask(TimeSpanFormatOptionsPresets.Range).AllFlags().First();
+            _truncate = options.Mask(TimeSpanFormatOptionsPresets.Truncate).AllFlags().First();
+            _lessThan = options.Mask(TimeSpanFormatOptionsPresets.LessThan) != TimeSpanFormatOptions.LessThanOff;
+            _abbreviate = options.Mask(TimeSpanFormatOptionsPresets.Abbreviate) != TimeSpanFormatOptions.AbbreviateOff;
             _round = _lessThan ? (Func<double, double>) Math.Floor : Math.Ceiling;
             _timeTextInfo = timeTextInfo;
 

--- a/src/SmartFormat/Utilities/Validation.cs
+++ b/src/SmartFormat/Utilities/Validation.cs
@@ -7,18 +7,15 @@ using System;
 
 namespace SmartFormat.Utilities
 {
-    internal class Validation
+    internal static class Validation
     {
-        protected Validation()
-        {
-            // Nothing to do here
-        }
+        private static readonly char[] Valid = new[] { '|', ',', '~' };
+
         public static char GetValidSplitCharOrThrow(char toCheck)
         {
-            var valid = new[] { '|', ',', '~' };
-            return toCheck == valid[0] || toCheck == valid[1] || toCheck == valid[2]
+            return toCheck == Valid[0] || toCheck == Valid[1] || toCheck == Valid[2]
                 ? toCheck
-                : throw new ArgumentException($"Only '{valid[0]}', '{valid[1]}' and '{valid[2]}' are valid split chars.");
+                : throw new ArgumentException($"Only '{Valid[0]}', '{Valid[1]}' and '{Valid[2]}' are valid split chars.");
         }
     }
 }


### PR DESCRIPTION
Hey. 2 very small refactors I added in our version.

1. Don't recreate the valid chars array each time in Validation.
2. Added `TimeSpanFormatOptionsPresets` so that internal use values are not exposed in the public enum. This is particularly important to us as we show the contents of the Enum in a dropdown selector for users and having internal use values would cause confusion. 