### PR TITLE
Use `is` instead of checking the type info.

### DIFF
--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -616,7 +616,7 @@ public class SmartFormatter
         if (Settings.StringFormatCompatibility)
         {
             return 
-                _formatterExtensions.First(fe => fe.GetType() == typeof(DefaultFormatter) || fe.GetType().BaseType == typeof(DefaultFormatter))
+                _formatterExtensions.First(fe => fe is DefaultFormatter)
                     .TryEvaluateFormat(formattingInfo);
         }
 

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -617,7 +617,7 @@ namespace SmartFormat
             if (Settings.StringFormatCompatibility)
             {
                 return 
-                    _formatterExtensions.First(fe => fe.GetType() == typeof(DefaultFormatter) || fe.GetType().BaseType == typeof(DefaultFormatter))
+                    _formatterExtensions.First(fe => fe is DefaultFormatter)
                     .TryEvaluateFormat(formattingInfo);
             }
 


### PR DESCRIPTION
A small simplification when checking the type, we use `is` now instead of checking twice. 