### PR TITLE
Avoid using Linq as it generates GC each time. 

### DIFF
--- a/src/SmartFormat/Core/Parsing/Format.cs
+++ b/src/SmartFormat/Core/Parsing/Format.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using SmartFormat.Core.Settings;
 using SmartFormat.Pooling.ObjectPools;
 using SmartFormat.Pooling.SmartPools;
@@ -106,11 +105,12 @@ public sealed class Format : FormatItem, IDisposable
 
         ParentPlaceholder = null;
         HasNested = false;
-            
+
         // Return and clear FormatItems we own
-        foreach (var item in Items.Where(i => ReferenceEquals(this, i.ParentFormatItem)))
+        foreach (var item in Items)
         {
-            ReturnFormatItemToPool(item);
+            if (ReferenceEquals(this, item.ParentFormatItem))
+                ReturnFormatItemToPool(item);
         }
         Items.Clear();
 
@@ -237,9 +237,9 @@ public sealed class Format : FormatItem, IDisposable
     public int IndexOf(char search, int start)
     {
         start = StartIndex + start;
-        foreach (var item in Items.Where(item => item.EndIndex >= start))
+        foreach (var item in Items)
         {
-            if (item is not LiteralText literalItem) continue;
+            if (item.EndIndex < start || item is not LiteralText literalItem) continue;
 
             if (start < literalItem.StartIndex) start = literalItem.StartIndex;
             var literalIndex =

--- a/src/SmartFormat/Core/Sources/Source.cs
+++ b/src/SmartFormat/Core/Sources/Source.cs
@@ -2,7 +2,6 @@
 // Copyright SmartFormat Project maintainers and contributors.
 // Licensed under the MIT license.
 
-using System.Linq;
 using SmartFormat.Core.Parsing;
 using SmartFormat.Core.Settings;
 
@@ -24,10 +23,7 @@ public abstract class Source : ISource, IInitializer
     protected SmartSettings? _smartSettings;
 
     /// <inheritdoc />
-    public virtual bool TryEvaluateSelector(ISelectorInfo selectorInfo)
-    {
-        return false;
-    }
+    public abstract bool TryEvaluateSelector(ISelectorInfo selectorInfo);
 
     /// <inheritdoc />
     public virtual void Initialize(SmartFormatter smartFormatter)
@@ -48,9 +44,15 @@ public abstract class Source : ISource, IInitializer
     /// </remarks>
     private bool HasNullableOperator(ISelectorInfo selectorInfo)
     {
-        return _smartSettings != null && selectorInfo.Placeholder != null &&
-               selectorInfo.Placeholder.Selectors.Any(s =>
-                   s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator);
+        if (_smartSettings != null && selectorInfo.Placeholder != null)
+        {
+            foreach (var s in selectorInfo.Placeholder.Selectors)
+            {
+                if (s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator)
+                    return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using SmartFormat.Core.Extensions;
 using SmartFormat.Core.Parsing;
@@ -300,9 +299,15 @@ public class ListFormatter : IFormatter, ISource, IInitializer
     /// </remarks>
     private bool HasNullableOperator(IFormattingInfo formattingInfo)
     {
-        return formattingInfo.Placeholder != null &&
-               formattingInfo.Placeholder.Selectors.Any(s =>
-                   s.OperatorLength > 0 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator);
+        if (formattingInfo.Placeholder != null)
+        {
+            foreach (var s in formattingInfo.Placeholder.Selectors)
+            {
+                if (s.OperatorLength > 0 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator)
+                    return true;
+            }
+        }
+        return false;
     }
 
     ///<inheritdoc />


### PR DESCRIPTION
I was doing some performance comparisons between our old version (2.x) and after upgrading to the latest version.
Previous formatting of a simple string such as "Hello {0} world {1}. This is a {0} test." would generate 0.6KB of garbage each run(after warmup).
When running with the latest version it was 2.6KB.
I found that most of this was coming from Source.cs `HasNullableOperator`. Its uses Linq which generates GC each time. So I have removed the usage of Linq in some of the critical parts. The GC is now down to around 0.5KB for us. 

I also made the Source.cs method `TryEvaluateSelector` abstract as it seemed to make more sense.