### PR TITLE
IConvertible support for plural and conditional formatters

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -106,6 +106,17 @@ public class ConditionalFormatterTests
         smart.Test(format, args, expected);
     }
 
+    [TestCase("{0:cond:Zero|Other} {1:cond:Zero|Other} {2:cond:Zero|Other}", "Zero Other Other")]
+    [TestCase("{0:cond:Zero|One|Other} {1:cond:Zero|One|Other} {2:cond:Zero|One|Other}", "Zero One Other")]
+    [TestCase("{0:cond:Zero|One|Two|Other} {1:cond:Zero|One|Two|Other} {2:cond:Zero|One|Two|Other}", "Zero One Two")]
+    [TestCase("{0:cond:>0?Positive|<0?Negative|=0?Zero}, {1:cond:>0?Positive|<0?Negative|=0?Zero}, {2:cond:>0?Positive|<0?Negative|=0?Zero}", "Zero, Positive, Positive")]
+    public void Test_IConvertible(string format, string expected)
+    {
+        var args = new object[] { new ConvertibleDecimal(0), new ConvertibleDecimal(1), new ConvertibleDecimal(2) };
+        var smart = Smart.CreateDefaultSmartFormat();
+        smart.Test(format, args, expected);
+    }
+
     [TestCase("{0:cond:>0?Positive|<0?Negative|=0?Zero}, {1:cond:>0?Positive|<0?Negative|=0?Zero}, {2:cond:>0?Positive|<0?Negative|=0?Zero}", "Negative, Zero, Positive")]
     [TestCase("{1:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]
     [TestCase("{2:cond:<1?Baby|>=1&<4?Toddler|>=4&<=9?Child|=10/=11/=12?Pre-Teen|<18?Teenager|<20?Young Adult|<20/<=24&<25?Early Twenties|>55&<100?Senior Citizen|>100?Crazy Old|Adult}", "Baby")]

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
+using SmartFormat.Tests.TestUtils;
 using SmartFormat.Utilities;
 using ExpectedResults = System.Collections.Generic.Dictionary<decimal, string>;
 
@@ -244,6 +245,18 @@ public class PluralLocalizationFormatterTests
 
         actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")), "{0:plural:une personne|deux personnes|plusieurs personnes|beaucoup de personnes}", new string[3], "several");
         Assert.AreEqual("beaucoup de personnes", actualResult);
+    }
+
+    [TestCase("{0:plural:one|many} {1:plural:one|many} {2:plural:one|many}", "many one many")]
+    [TestCase("There {0:plural:is|are} {0} {0:plural:item|items} remaining", "There are Convertible(0) items remaining")]
+    [TestCase("There {1:plural:is|are} {1} {1:plural:item|items} remaining", "There is Convertible(1) item remaining")]
+    public void Test_With_IConvertible(string format, string expectedResult)
+    {
+        var smart = GetFormatter();
+        var culture = new CultureInfo("en-US");
+        var args = new object[] { new ConvertibleDecimal(0), new ConvertibleDecimal(1), new ConvertibleDecimal(2) };
+        var actualResult = smart.Format(culture, format, args);
+        Assert.AreEqual(expectedResult, actualResult);
     }
 
     [Test]

--- a/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
+++ b/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace SmartFormat.Tests.TestUtils;
+
+class ConvertibleDecimal : IConvertible
+{
+    public decimal value;
+
+    public TypeCode GetTypeCode() => TypeCode.Decimal;
+    public decimal ToDecimal(IFormatProvider provider) => value;
+
+    public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
+    public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
+    public char ToChar(IFormatProvider provider) => throw new NotImplementedException();
+    public DateTime ToDateTime(IFormatProvider provider) => throw new NotImplementedException();
+    public double ToDouble(IFormatProvider provider) => throw new NotImplementedException();
+    public short ToInt16(IFormatProvider provider) => throw new NotImplementedException();
+    public int ToInt32(IFormatProvider provider) => throw new NotImplementedException();
+    public long ToInt64(IFormatProvider provider) => throw new NotImplementedException();
+    public sbyte ToSByte(IFormatProvider provider) => throw new NotImplementedException();
+    public float ToSingle(IFormatProvider provider) => throw new NotImplementedException();
+    public string ToString(IFormatProvider provider) => throw new NotImplementedException();
+    public object ToType(Type conversionType, IFormatProvider provider) => throw new NotImplementedException();
+    public ushort ToUInt16(IFormatProvider provider) => throw new NotImplementedException();
+    public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
+    public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
+
+    public override string ToString() => $"Convertible({value})";
+
+    public ConvertibleDecimal(decimal v) => value = v;
+}

--- a/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
+++ b/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
@@ -4,8 +4,8 @@ namespace SmartFormat.Tests.TestUtils;
 
 class ConvertibleDecimal : IConvertible
 {
-    public decimal _value;
-
+    private readonly decimal _value;
+    
     public TypeCode GetTypeCode() => TypeCode.Decimal;
     public decimal ToDecimal(IFormatProvider provider) => _value;
 

--- a/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
+++ b/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
@@ -4,10 +4,10 @@ namespace SmartFormat.Tests.TestUtils;
 
 class ConvertibleDecimal : IConvertible
 {
-    public decimal value;
+    public decimal _value;
 
     public TypeCode GetTypeCode() => TypeCode.Decimal;
-    public decimal ToDecimal(IFormatProvider provider) => value;
+    public decimal ToDecimal(IFormatProvider provider) => _value;
 
     public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
     public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
@@ -25,7 +25,7 @@ class ConvertibleDecimal : IConvertible
     public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
     public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
 
-    public override string ToString() => $"Convertible({value})";
+    public override string ToString() => $"Convertible({_value})";
 
-    public ConvertibleDecimal(decimal v) => value = v;
+    public ConvertibleDecimal(decimal v) => _value = v;
 }

--- a/src/SmartFormat/Extensions/ConditionalFormatter.cs
+++ b/src/SmartFormat/Extensions/ConditionalFormatter.cs
@@ -67,15 +67,15 @@ public class ConditionalFormatter : IFormatter
         }
 
         // See if the value is a number or an Enum:
-        var currentIsNumber =
-            current is byte or short or ushort or int or uint or long or ulong or float or double or decimal or Enum;
+        var currentIsConvertible = current is IConvertible &&
+                (current is not (DateTime or string or bool)); // We have special handling for these types
 
-        var currentNumber = currentIsNumber ? Convert.ToDecimal(current) : 0;
+        var currentNumber = currentIsConvertible ? Convert.ToDecimal(current) : 0;
 
         int paramIndex; // Determines which parameter to use for output
 
         // First, we'll see if we are using "complex conditions":
-        if (currentIsNumber)
+        if (currentIsConvertible)
         {
             paramIndex = -1;
             while (paramIndex++ < parameters.Count)
@@ -107,7 +107,7 @@ public class ConditionalFormatter : IFormatter
         var paramCount = parameters.Count;
 
         // Determine the Current item's Type:
-        if (currentIsNumber)
+        if (currentIsConvertible)
         {
             if (currentNumber < 0)
                 paramIndex = paramCount - 1;

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -113,8 +113,8 @@ public class PluralLocalizationFormatter : IFormatter
         // We can format numbers, and IEnumerables. For IEnumerables we look at the number of items
         // in the collection: this means the user can e.g. use the same parameter for both plural and list, for example
         // 'Smart.Format("The following {0:plural:person is|people are} impressed: {0:list:{}|, |, and}", new[] { "bob", "alice" });'
-        if (current is byte or short or ushort or int or uint  or long or ulong or float or double or decimal)
-            value = Convert.ToDecimal(current);
+        if (current is IConvertible convertible)
+            value = convertible.ToDecimal(null);
         else if (current is IEnumerable<object> objects)
             value = objects.Count();
         else


### PR DESCRIPTION
This is something we added for one of our users. 
We want to be able to pass in a class instance that contains various metadata and let it be evaluated against the plural and conditional formatters. At the moment they have to add another field and do something like `{tag.NumberValue:cond:<0?a|b}` however this makes it more complicated for translators to work with, having the extra NumberValue field. 

The `IConvertible` interface has a method for converting to Decimal, in fact, it's whats `Convert.ToDecimal` uses. It also turns out that all the primitive numbers implement this interface so it makes the code a bit simpler and maybe even more performant.

I had to add some exceptions for DateTime, bool, and string as they produce different results.
