### PR TITLE
Fixed: FormatItem.AsSpan()

### DIFF
--- a/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
+++ b/src/SmartFormat.Tests/TestUtils/ConvertibleDecimal.cs
@@ -2,30 +2,27 @@
 
 namespace SmartFormat.Tests.TestUtils;
 
-class ConvertibleDecimal : IConvertible
+public class ConvertibleDecimal : IConvertible
 {
     private readonly decimal _value;
     
     public TypeCode GetTypeCode() => TypeCode.Decimal;
-    public decimal ToDecimal(IFormatProvider provider) => _value;
-
-    public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
-    public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
-    public char ToChar(IFormatProvider provider) => throw new NotImplementedException();
-    public DateTime ToDateTime(IFormatProvider provider) => throw new NotImplementedException();
-    public double ToDouble(IFormatProvider provider) => throw new NotImplementedException();
-    public short ToInt16(IFormatProvider provider) => throw new NotImplementedException();
-    public int ToInt32(IFormatProvider provider) => throw new NotImplementedException();
-    public long ToInt64(IFormatProvider provider) => throw new NotImplementedException();
-    public sbyte ToSByte(IFormatProvider provider) => throw new NotImplementedException();
-    public float ToSingle(IFormatProvider provider) => throw new NotImplementedException();
-    public string ToString(IFormatProvider provider) => throw new NotImplementedException();
-    public object ToType(Type conversionType, IFormatProvider provider) => throw new NotImplementedException();
-    public ushort ToUInt16(IFormatProvider provider) => throw new NotImplementedException();
-    public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
-    public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
-
+    public decimal ToDecimal(IFormatProvider? provider) => _value;
+    public bool ToBoolean(IFormatProvider? provider) => throw new NotImplementedException();
+    public byte ToByte(IFormatProvider? provider) => throw new NotImplementedException();
+    public char ToChar(IFormatProvider? provider) => throw new NotImplementedException();
+    public DateTime ToDateTime(IFormatProvider? provider) => throw new NotImplementedException();
+    public double ToDouble(IFormatProvider? provider) => throw new NotImplementedException();
+    public short ToInt16(IFormatProvider? provider) => throw new NotImplementedException();
+    public int ToInt32(IFormatProvider? provider) => throw new NotImplementedException();
+    public long ToInt64(IFormatProvider? provider) => throw new NotImplementedException();
+    public sbyte ToSByte(IFormatProvider? provider) => throw new NotImplementedException();
+    public float ToSingle(IFormatProvider? provider) => throw new NotImplementedException();
+    public string ToString(IFormatProvider? provider) => throw new NotImplementedException();
+    public object ToType(Type conversionType, IFormatProvider? provider) => throw new NotImplementedException();
+    public ushort ToUInt16(IFormatProvider? provider) => throw new NotImplementedException();
+    public uint ToUInt32(IFormatProvider? provider) => throw new NotImplementedException();
+    public ulong ToUInt64(IFormatProvider? provider) => throw new NotImplementedException();
     public override string ToString() => $"Convertible({_value})";
-
     public ConvertibleDecimal(decimal v) => _value = v;
 }

--- a/src/SmartFormat/Core/Parsing/Format.cs
+++ b/src/SmartFormat/Core/Parsing/Format.cs
@@ -106,12 +106,15 @@ public sealed class Format : FormatItem, IDisposable
         ParentPlaceholder = null;
         HasNested = false;
 
+#pragma warning disable S3267 // Don't use LINQ in favor of less GC
         // Return and clear FormatItems we own
         foreach (var item in Items)
         {
             if (ReferenceEquals(this, item.ParentFormatItem))
                 ReturnFormatItemToPool(item);
         }
+#pragma warning restore S3267 // Restore: Loops should be simplified with "LINQ" expressions
+
         Items.Clear();
 
         // Return and clear the list of SplitLists
@@ -237,6 +240,7 @@ public sealed class Format : FormatItem, IDisposable
     public int IndexOf(char search, int start)
     {
         start = StartIndex + start;
+#pragma warning disable S3267 // Don't use LINQ in favor of less GC
         foreach (var item in Items)
         {
             if (item.EndIndex < start || item is not LiteralText literalItem) continue;
@@ -246,6 +250,7 @@ public sealed class Format : FormatItem, IDisposable
                 literalItem.BaseString.IndexOf(search, start, literalItem.EndIndex - start);
             if (literalIndex != -1) return literalIndex - StartIndex;
         }
+#pragma warning restore S3267 // Restore: Loops should be simplified with "LINQ" expressions
 
         return -1;
     }

--- a/src/SmartFormat/Core/Parsing/FormatItem.cs
+++ b/src/SmartFormat/Core/Parsing/FormatItem.cs
@@ -104,6 +104,6 @@ public abstract class FormatItem
     /// </summary>
     /// <returns>The <see cref="ReadOnlySpan{T}"/> representation of this <see cref="FormatItem"/></returns>
     public virtual ReadOnlySpan<char> AsSpan() => EndIndex <= StartIndex
-        ? BaseString.AsSpan(StartIndex)
+        ? ReadOnlySpan<char>.Empty
         : BaseString.AsSpan(StartIndex, Length);
 }

--- a/src/SmartFormat/Core/Sources/Source.cs
+++ b/src/SmartFormat/Core/Sources/Source.cs
@@ -46,11 +46,13 @@ public abstract class Source : ISource, IInitializer
     {
         if (_smartSettings != null && selectorInfo.Placeholder != null)
         {
+#pragma warning disable S3267 // Don't use LINQ in favor of less GC
             foreach (var s in selectorInfo.Placeholder.Selectors)
             {
                 if (s.OperatorLength > 1 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator)
                     return true;
             }
+#pragma warning restore S3267 // Restore: Loops should be simplified with "LINQ" expressions
         }
         return false;
     }

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -35,7 +35,7 @@ public class DefaultFormatter : IFormatter
         var current = formattingInfo.CurrentValue;
             
         // If the format has nested placeholders, we process those first
-        // instead of formatting the item.
+        // instead of formatting the item. Like with "{2:list:{:{FirstName}}|, }"
         if (format is {HasNested: true})
         {
             formattingInfo.FormatAsChild(format, current);

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -301,11 +301,13 @@ public class ListFormatter : IFormatter, ISource, IInitializer
     {
         if (formattingInfo.Placeholder != null)
         {
+#pragma warning disable S3267 // Don't use LINQ in favor of less GC
             foreach (var s in formattingInfo.Placeholder.Selectors)
             {
                 if (s.OperatorLength > 0 && s.BaseString[s.OperatorStartIndex] == _smartSettings.Parser.NullableOperator)
                     return true;
             }
+#pragma warning restore S3267 // Restore: Loops should be simplified with "LINQ" expressions
         }
         return false;
     }

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -385,8 +385,6 @@ public class SmartFormatter
             var childFormattingInfo = formattingInfo.CreateChild(placeholder);
             try
             {
-                // Note: If there is no selector (like {:0.00}),
-                // FormattingInfo.CurrentValue is left unchanged
                 EvaluateSelectors(childFormattingInfo);
             }
             catch (Exception ex)
@@ -529,6 +527,16 @@ public class SmartFormatter
                 "No formatter extensions are available. Please add at least one formatter extension, such as the DefaultFormatter.");
     }
 
+    /// <summary>
+    /// Evaluates all <see cref="Selector"/>s of a <see cref="Placeholder"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note: If there is no selector (like {:0.00}), <see cref="FormattingInfo.CurrentValue"/> is left unchanged.
+    /// <br/>
+    /// Child formats <b>inside <see cref="Placeholder"/>s</b> are evaluated in <see cref="DefaultFormatter"/>.
+    /// Example: "{ChildOne.ChildTwo.ChildThree: {Four}}" where "{Four}" is a child placeholder.
+    /// </remarks>
+    /// <param name="formattingInfo"></param>
     private void EvaluateSelectors(FormattingInfo formattingInfo)
     {
         if (formattingInfo.Placeholder is null) return;
@@ -553,7 +561,8 @@ public class SmartFormatter
             if (firstSelector)
             {
                 firstSelector = false;
-                // Handle "nested scopes" by traversing the stack:
+                // Handle "nested scopes" like "{ChildOne.ChildTwo.ChildThree: {Four}}
+                // by traversing the stack:
                 var parentFormattingInfo = formattingInfo;
                 while (!handled && parentFormattingInfo.Parent != null)
                 {


### PR DESCRIPTION
* Fixed: FormatItem.AsSpan() now returns ReadOnlySpan<char>.Empty for EndIndex <= StartIndex
* Partly disable SonarClooud warning S3267
* Updated comments and xmldoc
* Refactored IConvertible unit tests