### PR TITLE
Ignore bools in plurals formatter.

### DIFF
--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -309,4 +309,17 @@ public class PluralLocalizationFormatterTests
         var result = smart.Format(format, data);
         Assert.That(result, Is.EqualTo(expected));
     }
+
+    [Test]
+    public void DoesNotHandle_Bool_WhenCanAutoDetect_IsTrue()
+    {
+        var smart = new SmartFormatter()
+            .AddExtensions(new DefaultSource())
+            .AddExtensions(new PluralLocalizationFormatter { CanAutoDetect = true }, // Should not handle the bool
+            new ConditionalFormatter { CanAutoDetect = true }, // Should handle the bool
+            new DefaultFormatter());
+
+        var result = smart.Format(new CultureInfo("ar"), "{0:yes|no}", true);
+        Assert.That(result, Is.EqualTo("yes"));
+    }
 }

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -113,7 +113,7 @@ public class PluralLocalizationFormatter : IFormatter
         // We can format numbers, and IEnumerables. For IEnumerables we look at the number of items
         // in the collection: this means the user can e.g. use the same parameter for both plural and list, for example
         // 'Smart.Format("The following {0:plural:person is|people are} impressed: {0:list:{}|, |, and}", new[] { "bob", "alice" });'
-        if (current is IConvertible convertible)
+        if (current is IConvertible convertible && current is not bool)
             value = convertible.ToDecimal(null);
         else if (current is IEnumerable<object> objects)
             value = objects.Count();


### PR DESCRIPTION
I introduced a small bug in my last PR. The plurals formatter will now also consider bools which changes the behaviors when it is using auto detect. This was causing some of our tests to fail because we had an Arabic language running at the time which produces different plurals.