### PR TITLE
Change all public types in namespace Cysharp.Text to internal

### DIFF
--- a/src/SmartFormat.ZString/ZStringWriter.cs
+++ b/src/SmartFormat.ZString/ZStringWriter.cs
@@ -8,13 +8,14 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Cysharp.Text;
 
 /*
  *  The ZStringWriter class from the repo is excluded from the project
  *  and replaced with this modified version, so we can compile for TFM net461 
  */
 
-namespace Cysharp.Text;
+namespace SmartFormat.ZString;
 
 /// <summary>
 /// A <see cref="TextWriter"/> implementation that is backed with <see cref="Utf16ValueStringBuilder"/>.
@@ -40,7 +41,7 @@ public sealed class ZStringWriter : TextWriter
     /// </summary>
     public ZStringWriter(IFormatProvider formatProvider) : base(formatProvider)
     {
-        sb = ZString.CreateStringBuilder();
+        sb = Cysharp.Text.ZString.CreateStringBuilder();
         isOpen = true;
     }
 

--- a/src/SmartFormat.ZString/repo/src/ZString/FormatParser.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/FormatParser.cs
@@ -7,7 +7,7 @@ namespace Cysharp.Text
     {
         // {index[,alignment][:formatString]}
 
-        public readonly ref struct ParseResult
+        internal readonly ref struct ParseResult
         {
             public readonly int Index;
             public readonly ReadOnlySpan<char> FormatString;

--- a/src/SmartFormat.ZString/repo/src/ZString/IResettableBufferWriter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/IResettableBufferWriter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Cysharp.Text
 {
-    public interface IResettableBufferWriter<T> : IBufferWriter<T>
+    internal interface IResettableBufferWriter<T> : IBufferWriter<T>
     {
         void Reset();
     }

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/BitOperations.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/BitOperations.cs
@@ -15,7 +15,7 @@ namespace System.Numerics
     /// The methods use hardware intrinsics when available on the underlying platform,
     /// otherwise they use optimized software fallbacks.
     /// </summary>
-    public static class BitOperations
+    internal static class BitOperations
     {
         // C# no-alloc optimization that directly wraps the data section of the dll (similar to string constants)
         // https://github.com/dotnet/roslyn/pull/24621

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/HexConverter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/HexConverter.cs
@@ -8,7 +8,7 @@ namespace System
 {
     internal static class HexConverter
     {
-        public enum Casing : uint
+        internal enum Casing : uint
         {
             // Output [ '0' .. '9' ] and [ 'A' .. 'F' ].
             Upper = 0,

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/Number.NumberToFloatingPointBits.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/Number.NumberToFloatingPointBits.cs
@@ -15,7 +15,7 @@ namespace System
             return *((int*)&value);
         }
 
-        public readonly struct FloatingPointInfo
+        internal readonly struct FloatingPointInfo
         {
             public static readonly FloatingPointInfo Double = new FloatingPointInfo(
                 denormalMantissaBits: 52,

--- a/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public sealed partial class Utf16PreparedFormat<T1>
+    internal sealed partial class Utf16PreparedFormat<T1>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -69,7 +69,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2>
+    internal sealed partial class Utf16PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -139,7 +139,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -214,7 +214,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -294,7 +294,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -379,7 +379,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -469,7 +469,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -564,7 +564,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -664,7 +664,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -769,7 +769,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -879,7 +879,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -994,7 +994,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1114,7 +1114,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1239,7 +1239,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1369,7 +1369,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1504,7 +1504,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1644,7 +1644,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1>
+    internal sealed partial class Utf8PreparedFormat<T1>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1710,7 +1710,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2>
+    internal sealed partial class Utf8PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1781,7 +1781,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1857,7 +1857,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1938,7 +1938,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2024,7 +2024,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2115,7 +2115,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2211,7 +2211,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2312,7 +2312,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2418,7 +2418,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2529,7 +2529,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2645,7 +2645,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2766,7 +2766,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2892,7 +2892,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -3023,7 +3023,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -3159,7 +3159,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
         public int MinSize { get; }

--- a/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.tt
@@ -13,7 +13,7 @@ namespace Cysharp.Text
 {
 <# foreach(var utf in utfTypes) { var isUtf16 = (utf == "Utf16"); #>
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
-    public sealed partial class <#= utf #>PreparedFormat<<#= CreateTypeArgument(i) #>>
+    internal sealed partial class <#= utf #>PreparedFormat<<#= CreateTypeArgument(i) #>>
     {
         public string FormatString { get; }
         public int MinSize { get; }

--- a/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.
@@ -209,7 +209,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.

--- a/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.tt
@@ -15,7 +15,7 @@ using System.Runtime.CompilerServices;
 namespace Cysharp.Text
 {
 <# foreach(var utf in utfTypes) { #>
-    public partial struct <#= utf #>ValueStringBuilder
+    internal partial struct <#= utf #>ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.

--- a/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.cs
@@ -3,7 +3,7 @@ using TMPro;
 
 namespace Cysharp.Text
 {
-    public static partial class TextMeshProExtensions
+    internal static partial class TextMeshProExtensions
     {
         public static void SetText<T>(this TMP_Text text, T arg0)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.tt
@@ -26,7 +26,7 @@ using TMPro;
 
 namespace Cysharp.Text
 {
-    public static partial class TextMeshProExtensions
+    internal static partial class TextMeshProExtensions
     {
         public static void SetText<T>(this TMP_Text text, T arg0)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
@@ -9,7 +9,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
@@ -35,7 +35,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.tt
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
 <# foreach(var t in spanFormattables) { #>
         /// <summary>Appends the string representation of a specified value to this instance.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16ValueStringBuilder.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder : IDisposable, IBufferWriter<char>, IResettableBufferWriter<char>
+    internal partial struct Utf16ValueStringBuilder : IDisposable, IBufferWriter<char>, IResettableBufferWriter<char>
     {
         public delegate bool TryFormat<T>(T value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format);
 
@@ -727,7 +727,7 @@ namespace Cysharp.Text
             RegisterTryFormat<T?>(CreateNullableFormatter<T>());
         }
 
-        public static class FormatterCache<T>
+        internal static class FormatterCache<T>
         {
             public static TryFormat<T> TryFormatDelegate;
             static FormatterCache()

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
@@ -10,7 +10,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
@@ -4,7 +4,7 @@ using System.Buffers.Text;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
@@ -11,7 +11,7 @@ using System.Buffers.Text;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
 <# foreach(var t in utf8spanFormattables) { #>
         /// <summary>Appends the string representation of a specified value to this instance.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8ValueStringBuilder.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder : IDisposable, IBufferWriter<byte>, IResettableBufferWriter<byte>
+    internal partial struct Utf8ValueStringBuilder : IDisposable, IBufferWriter<byte>, IResettableBufferWriter<byte>
     {
         public delegate bool TryFormat<T>(T value, Span<byte> destination, out int written, StandardFormat format);
 
@@ -513,7 +513,7 @@ namespace Cysharp.Text
             RegisterTryFormat<T?>(CreateNullableFormatter<T>());
         }
 
-        public static class FormatterCache<T>
+        internal static class FormatterCache<T>
         {
             public static TryFormat<T> TryFormatDelegate;
             static FormatterCache()

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Concatenates the string representation of some specified objects.</summary>
         public static string Concat<T1>(T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.tt
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Concatenates the string representation of some specified objects.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.tt
@@ -10,7 +10,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Prepare string format to avoid parse template in each operation.</summary>
         public static Utf16PreparedFormat<T1> PrepareUtf16<T1>(string format)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.tt
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Prepare string format to avoid parse template in each operation.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.cs
@@ -6,7 +6,7 @@ using static Cysharp.Text.Utf8ValueStringBuilder;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1>(IBufferWriter<byte> bufferWriter, string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.tt
@@ -13,7 +13,7 @@ using static Cysharp.Text.Utf8ValueStringBuilder;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         static Encoding UTF8NoBom = new UTF8Encoding(false);
 

--- a/src/SmartFormat.ZString/repo/src/ZString/ZStringWriter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZStringWriter.cs
@@ -13,7 +13,7 @@ namespace Cysharp.Text
     /// <remarks>
     /// It's important to make sure the writer is always properly disposed.
     /// </remarks>
-    public sealed class ZStringWriter : TextWriter
+    internal sealed class ZStringWriter : TextWriter
     {
         private Utf16ValueStringBuilder sb;
         private bool isOpen;


### PR DESCRIPTION
Resolves #303

* Affects: class, struct, interface, delegate, enum
* using https://github.com/zzzprojects/findandreplace on command line, so we can automate this step:
`"fnr.exe" --cl --dir "SmartFormat.ZString\repo\src\ZString" --fileMask "*.cs,*.tt" --includeSubDirectories --caseSensitive --useRegEx --find "public (?=.*(class |struct |enum |interface |delegate ))" --replace "internal "`