### PR TITLE
ListFormatter handles selector name "Index" in IEnumerable and IList

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -64,6 +65,22 @@ public class ListFormatterTests
         var smart = Smart.CreateDefaultSmartFormat();
         var result = smart.Format("{TheList?:list:{}|, |, and }", new { TheList = default(object)});
         Assert.AreEqual(string.Empty, result);
+    }
+
+    [Test]
+    public void Enumerable_With_SelectorName_Index_Is_Recognized()
+    {
+        var smart = Smart.CreateDefaultSmartFormat();
+        var objects = new object[]
+        {
+            new { Content = "Content A" },
+            new { Content = "Content B" }
+        };
+
+        // Linq Select returns an IEnumerable.
+        // "Index" selector should be recognized even when the argument is not an IList
+        var result = smart.Format("{0:{Content} with Index {Index}|, }", objects.Select(x => x));
+        Assert.That(result, Is.EqualTo("Content A with Index 0, Content B with Index 1"));
     }
 
     [Test]

--- a/src/SmartFormat/Extensions/ReflectionSource.cs
+++ b/src/SmartFormat/Extensions/ReflectionSource.cs
@@ -44,7 +44,6 @@ public class ReflectionSource : Source
     /// <inheritdoc />
     public override bool TryEvaluateSelector(ISelectorInfo selectorInfo)
     {
-            
         var current = selectorInfo.CurrentValue;
             
         if (TrySetResultForNullableOperator(selectorInfo)) return true;
@@ -95,7 +94,7 @@ public class ReflectionSource : Source
             switch (member.MemberType)
             {
                 case MemberTypes.Field:
-                    //  Selector is a Field; retrieve the value:
+                    // Selector is a Field; retrieve the value:
                     var field = member as FieldInfo;
                     selectorInfo.Result = field?.GetValue(current);
                     if (IsTypeCacheEnabled) TypeCache[(sourceType, selector)] = (field, null);
@@ -104,17 +103,17 @@ public class ReflectionSource : Source
                 case MemberTypes.Method:
                     if (!TryGetMethodInfo(member, out var method)) continue;
  
-                    //  Check that this method is valid -- it needs to return a value and has to be parameter-less:
-                    //  We are only looking for a parameter-less Function/Property:
+                    // Check that this method is valid -- it needs to return a value and has to be parameter-less:
+                    // We are only looking for a parameter-less Function/Property:
                     if (method?.GetParameters().Length > 0) continue;
 
-                    //  Make sure that this method is not void! It has to be a Function!
+                    // Make sure that this method is not void! It has to be a Function!
                     if (method?.ReturnType == typeof(void)) continue;
 
                     // Add to cache
                     if (IsTypeCacheEnabled) TypeCache[(sourceType, selector)] = (null, method);
 
-                    //  Retrieve the Selectors/ParseFormat value:
+                    // Retrieve the Selectors/ParseFormat value:
                     selectorInfo.Result = method?.Invoke(current, Array.Empty<object>());
                     return true;
             }


### PR DESCRIPTION
Fixes #313 for `ListFormatter`:
In `v1.6.1` a Selector was tested for having the name **"index"**, even if data was not an `IList`, and returned the `CollectionIndex`. This is now implemented again in the `ListFormatter.TryEvaluateSelector(...)`
