### PR TITLE
Bump version to v3.2.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
       - ps: dotnet restore SmartFormat.sln --verbosity quiet
       - ps: dotnet add .\SmartFormat.Tests\SmartFormat.Tests.csproj package AltCover
       - ps: |
-          $version = "3.1.0"
+          $version = "3.2.0"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) SmartFormat Project</Copyright>
         <RepositoryUrl>https://github.com/axuno/SmartFormat.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>3.1.0</Version>
-        <FileVersion>3.1.0</FileVersion>
+        <Version>3.2.0</Version>
+        <FileVersion>3.2.0</FileVersion>
         <AssemblyVersion>3.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
### Enhancements

* Remove usage of Linq for less GC
* Add `IConvertable` support for `PluralLocalizationFormatter` and `ConditionalFormatter`
* `ListFormatter`
  * ListFormatter handles selector name "Index" in `IEnumerable`s and `IList`s: In `v1.6.1` a Selector was tested for having the name **"index"**, even if data was not an `IList`, and returned the `CollectionIndex`. This is now implemented again in the `ListFormatter.TryEvaluateSelector(...)`
  * Set the `ParentPlaceholder` property for item `Format`s
  * Use `PooledObject<T>` where possible, so objects will be returned to `ObjectPool` also in case of exceptions

### Fixes
* `FormatItem.AsSpan()` returns the correct name
* Remove potential namespace collisions: All public types in namespace `Cysharp.Text` are now internal