### PR TITLE
PluralLocalizationFormatter: Fix processing for Singular languages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ for:
           }
     test_script:
       - cmd: nuget install Appveyor.TestLogger
-      - cmd: dotnet test --no-build --framework net6.0 --test-adapter-path:. --logger:Appveyor SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|SmartFormat.ZString|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - cmd: dotnet test --framework net6.0 --test-adapter-path:. --logger:Appveyor SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|SmartFormat.ZString|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - cmd: nuget install codecov -excludeversion
       - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\SmartFormat.Tests\coverage.net6.0.xml" -n net6.0win
     artifacts:

--- a/src/Performance_v27/Performance_v27.csproj
+++ b/src/Performance_v27/Performance_v27.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AssemblyOriginatorKeyFile>../SmartFormat/SmartFormat.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -49,6 +49,18 @@ public class PluralLocalizationFormatterTests
         Assert.That(() => smart.Format("{0:plural:One|Two}", new object()), Throws.Exception.TypeOf<FormattingException>());
     }
 
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(100)]
+    public void Explicit_Should_Process_Singular_PluralRule(int count)
+    {
+        var smart = Smart.CreateDefaultSmartFormat();
+        // Japanese does not have plural definitions (is a Singular language)
+        // "リンゴを2個持っています。" => "I have 2 apple(s)"
+        var result = smart.Format("リンゴを{0:plural(ja):{}個持っています。}", count);
+        Assert.That(result, Is.EqualTo($"リンゴを{count}個持っています。"));
+    }
+
     [Test]
     public void Test_Default()
     {

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -18,10 +18,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="FluentAssertions" Version="6.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
 	</ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -70,7 +70,21 @@ public class PluralLocalizationFormatter : IFormatter
     ///<inheritdoc/>
     public string Name { get; set; } = "plural";
 
-    ///<inheritdoc/>
+    /// <summary>
+    /// Any extensions marked as <see cref="CanAutoDetect"/> will be called implicitly
+    /// (when no formatter name is specified in the input format string).
+    /// For example, "{0:N2}" will implicitly call extensions marked as <see cref="CanAutoDetect"/>.
+    /// Implicit formatter invocations should not throw exceptions.
+    /// With <see cref="CanAutoDetect"/> == <see langword="false"/>, the formatter can only be
+    /// called by its name in the input format string.
+    /// <para/>
+    /// <b>Auto detection only works with more than 1 format argument.
+    /// Is recommended to set <see cref="CanAutoDetect"/> to <see langword="false"/>. This will be the default in a future version.
+    /// </b>
+    /// </summary>
+    /// <remarks>
+    /// If more than one registered <see cref="IFormatter"/> can auto-detect, the first one in the formatter list will win.
+    /// </remarks>
     public bool CanAutoDetect { get; set; } = true;
 
     /// <summary>
@@ -93,17 +107,13 @@ public class PluralLocalizationFormatter : IFormatter
 
         // Extract the plural words from the format string:
         var pluralWords = format.Split(SplitChar);
-        // This extension requires at least two plural words:
-        if (pluralWords.Count == 1)
+
+        // This extension requires at least two plural words for auto detection
+        // For locales
+        if (pluralWords.Count <= 1 && string.IsNullOrEmpty(formattingInfo.Placeholder?.FormatterName))
         {
             // Auto detection calls just return a failure to evaluate
-            if (string.IsNullOrEmpty(formattingInfo.Placeholder?.FormatterName))
-                return false;
-
-            // throw, if the formatter has been called explicitly
-            throw new FormatException(
-                $"Formatter named '{formattingInfo.Placeholder?.FormatterName}' requires at least 2 plural words.");
-
+            return false;
         }
 
         decimal value;

--- a/src/SmartFormat/SmartFormat.csproj
+++ b/src/SmartFormat/SmartFormat.csproj
@@ -53,7 +53,7 @@ https://github.com/axuno/SmartFormat/blob/main/CHANGES.md
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Resolves #320 

* Fix: Throws FormattingException for Singular languages
* Add unit test for Singular language (Japanese)
* Auto detection only works with more than 1 format argument.
* Is recommended to set CanAutoDetect to false. This will be the default in a future version. Added xmdoc with this hint.