### PR TITLE
Fix: PluralRules for Czech locale

### DIFF
--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -176,6 +176,22 @@ public class PluralLocalizationFormatterTests
     }
 
     [Test]
+    public void Test_Czech()
+    {
+        TestAllResults(
+            new CultureInfo("cs"),
+            "{0:plural:Nemáte zprávu|Máte {} zprávu|Přišly Vám {} zprávy|Přišlo Vám {} zpráv}!",
+            new ExpectedResults {
+                {   0, "Nemáte zprávu!"},
+                {   1, "Máte 1 zprávu!"},
+                {   2, "Přišly Vám 2 zprávy!"},
+                {   4, "Přišly Vám 4 zprávy!"},
+                {   5, "Přišlo Vám 5 zpráv!"},
+                {   6, "Přišlo Vám 6 zpráv!"},
+            });
+    }
+
+    [Test]
     public void Test_Polish()
     {
         TestAllResults(

--- a/src/SmartFormat/Utilities/PluralRules.cs
+++ b/src/SmartFormat/Utilities/PluralRules.cs
@@ -267,13 +267,12 @@ public static class PluralRules
             _ => 5  // other
         }; 
     private static PluralRuleDelegate Czech => (value, pluralWordsCount) =>
-        value switch
-        {
-            0 => 0, // zero
-            1 => 1, // one
-            > 1 and < 5 => 2, // few
-            _ => 3  // other
-        };
+        value == 0 ? 0 : // zero
+        value == 1 ? 1 : // one
+        value.Between(2, 4) ? 2 : // few
+        value % 1 == 0 ? 3 : // many
+        4;  // other
+
     private static PluralRuleDelegate Welsh => (value, pluralWordsCount) =>
         value switch
         {

--- a/src/SmartFormat/Utilities/PluralRules.cs
+++ b/src/SmartFormat/Utilities/PluralRules.cs
@@ -267,9 +267,13 @@ public static class PluralRules
             _ => 5  // other
         }; 
     private static PluralRuleDelegate Czech => (value, pluralWordsCount) =>
-        value == 1 ? 0 : // one
-        value.Between(2, 4) ? 1 : // few
-        2;
+        value switch
+        {
+            0 => 0, // zero
+            1 => 1, // one
+            > 1 and < 5 => 2, // few
+            _ => 3  // other
+        };
     private static PluralRuleDelegate Welsh => (value, pluralWordsCount) =>
         value switch
         {


### PR DESCRIPTION
I added new Czech PluralRuleDelegate according to Czech grammar. It would break the usage of an old rule, however I don't believe it could have been used in real word. The test should be:

    public void SmartFormatPluralTest()
    {
        var c = new CustomPluralRuleProvider(Czech);
        string msg = "{0:plural:Nemáte zprávu|Máte {} zprávu|Přišly Vám {} zprávy|Přišlo Vám {} zpráv}!";
        Smart.Format(c, msg, 0).Should().Be("Nemáte zprávu!");
        Smart.Format(c, msg, 1).Should().Be("Máte 1 zprávu!");
        Smart.Format(c, msg, 2).Should().Be("Přišly Vám 2 zprávy!");
        Smart.Format(c, msg, 4).Should().Be("Přišly Vám 4 zprávy!");
        Smart.Format(c, msg, 5).Should().Be("Přišlo Vám 5 zpráv!");
        Smart.Format(c, msg, 6).Should().Be("Přišlo Vám 6 zpráv!");
    }