### PR TITLE
Fix: Auto-detection of PluralLocalizationFormatter does not throw for values not convertible to decimal

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -13,14 +13,14 @@ jobs:
     # (PRs from forks can't access secrets other than secrets.GITHUB_TOKEN for security reasons)
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
-      version: '3.1.0'
-      versionFile: '3.1.0'
+      version: '3.2.1'
+      versionFile: '3.2.1'
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0   # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
@@ -60,7 +60,7 @@ jobs:
           echo "Packing Version: ${{ env.version }}, File Version: ${{ env.versionFile }}"
           dotnet pack ./src/SmartFormat.Deploy.sln /verbosity:minimal --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:PackageOutputPath=${{ github.workspace }}/artifacts /p:Version=${{ env.version }} /p:FileVersion=${{ env.versionFile }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Packages_${{ env.version }}
           path: ${{ github.workspace }}/artifacts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
       - ps: dotnet restore SmartFormat.sln --verbosity quiet
       - ps: dotnet add .\SmartFormat.Tests\SmartFormat.Tests.csproj package AltCover
       - ps: |
-          $version = "3.2.0"
+          $version = "3.2.1"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) SmartFormat Project</Copyright>
         <RepositoryUrl>https://github.com/axuno/SmartFormat.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>3.2.0</Version>
-        <FileVersion>3.2.0</FileVersion>
+        <Version>3.2.1</Version>
+        <FileVersion>3.2.1</FileVersion>
         <AssemblyVersion>3.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -350,4 +350,21 @@ public class PluralLocalizationFormatterTests
         var result = smart.Format(new CultureInfo("ar"), "{0:yes|no}", true);
         Assert.That(result, Is.EqualTo("yes"));
     }
+
+    [TestCase("A", "[A]")]
+    [TestCase(default(string?), "null")]
+    public void DoesNotHandle_NonDecimalValues_WhenCanAutoDetect_IsTrue(string? category, string expected)
+    {
+        var smart = new SmartFormatter()
+            .AddExtensions(new DefaultSource())
+            .AddExtensions(new ReflectionSource())
+            // Should not handle because "Category" value cannot convert to decimal
+            .AddExtensions(new PluralLocalizationFormatter { CanAutoDetect = true },
+                // Should detect and handle the format
+                new ConditionalFormatter { CanAutoDetect = true },
+                new DefaultFormatter());
+
+        var result = smart.Format(new CultureInfo("en"), "{Category:[{}]|null}", new { Category = category });
+        Assert.That(result, Is.EqualTo(expected));
+    }
 }

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -159,7 +159,7 @@ public class PluralLocalizationFormatter : IFormatter
         return true;
     }
 
-    private bool TryGetDecimalValue(IConvertible convertible, IFormatProvider? provider,  out decimal value)
+    private static bool TryGetDecimalValue(IConvertible convertible, IFormatProvider? provider,  out decimal value)
     {
         try
         {


### PR DESCRIPTION
Resolves #329

#### Current behavior, introduced in v3.2.0:
When `PluralLocalizationFormatter.CanAutoDetect == true`, values that are not convertible to `decimal` will throw then trying to `IConvertible.ToDecimal(...)`

#### New behavior:
When `PluralLocalizationFormatter.CanAutoDetect == true`, for values that are not convertible to `decimal`, `IFormatter.TryEvaluateFormat(...)` will return `false`

@karljj1 Makes sense?