### PR TITLE
Bump NUnit package reference to v4.0.1

### DIFF
--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -19,7 +19,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.10.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Test code has already been updated as described below.

Note 1:
* ReSharper prior to v2023.3.2 may not recognize NUnit 4 tests. The VS2022 Test Explorer, however, shows the tests.

Note 2:
* NUnit v4 has breaking changes compared to v3.
* NUnit.Analyzer has rules and associated code fixes. This must be done while working on v3. The analyzers only run when the code compiles.