### PR TITLE
PluralRule for DualFromZeroToTwo: Does not cover value of 2 - Closes #369

### DIFF
--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using NUnit.Framework;
@@ -23,12 +24,12 @@ public class PluralLocalizationFormatterTests
 
     private static void TestAllResults(CultureInfo cultureInfo, string format, ExpectedResults expectedValuesAndResults)
     {
-        foreach (var test in expectedValuesAndResults)
+        foreach (var testResult in expectedValuesAndResults)
         {
             var smart = GetFormatter();
-            var value = test.Key;
-            var expected = test.Value;
-            var actual = smart.Format(cultureInfo, format, value);
+            var count = testResult.Key;
+            var expected = testResult.Value;
+            var actual = smart.Format(cultureInfo, format, count);
 
             Assert.That(actual, Is.EqualTo(expected));
             Debug.WriteLine(actual);
@@ -153,6 +154,45 @@ public class PluralLocalizationFormatterTests
         }
     }
 
+    [TestCase(0, "{0} personne")] // 0 is singular
+    [TestCase(1, "{0} personne")] // 1 is singular
+    [TestCase(2, "{0} personnes")] // 2 or more is plural
+    [TestCase(50, "{0} personnes")]
+    public void Test_French_2words(int count, string expected)
+    {
+        var smart = GetFormatter();
+        var ci = CultureInfo.GetCultureInfo("fr");
+        var actual = smart.Format(ci, "{0:plural:{0} personne|{0} personnes}", count);
+
+        Assert.That(actual, Is.EqualTo(string.Format(ci, expected, count)));
+    }
+
+    [TestCase(0, "pas de personne")] // 0 is singular
+    [TestCase(1, "une personne")] // 1 is singular
+    [TestCase(2, "{0} personnes")] // 2 or more is plural
+    [TestCase(50, "{0} personnes")]
+    public void Test_French_3words(int count, string expected)
+    {
+        var smart = GetFormatter();
+        var ci = CultureInfo.GetCultureInfo("fr");
+        var actual = smart.Format(ci, "{0:plural:pas de personne|une personne|{0} personnes}", count);
+
+        Assert.That(actual, Is.EqualTo(string.Format(ci, expected, count)));
+    }
+
+    [TestCase(0, "pas de personne")] // 0 is singular
+    [TestCase(1, "une personne")] // 1 is singular
+    [TestCase(2, "deux personnes")] // 2 is plural
+    [TestCase(50, "{0} personnes")] // more than 2
+    public void Test_French_4words(int count, string expected)
+    {
+        var smart = GetFormatter();
+        var ci = CultureInfo.GetCultureInfo("fr");
+        var actual = smart.Format(ci, "{0:plural:pas de personne|une personne|deux personnes|{0} personnes}", count);
+
+        Assert.That(actual, Is.EqualTo(string.Format(ci, expected, count)));
+    }
+
     [Test]
     public void Test_Turkish()
     {
@@ -273,7 +313,7 @@ public class PluralLocalizationFormatterTests
     [TestCase("{0:plural:zero|one|many}", new string[0], "zero")]
     [TestCase("{0:plural:zero|one|many}", new[] { "alice" }, "one")]
     [TestCase("{0:plural:zero|one|many}", new[] { "alice", "bob" }, "many")]
-    public void Test_should_allow_ienumerable_parameter(string format, object arg0, string expectedResult)
+    public void Should_Allow_IEnumerable_Parameter(string format, object arg0, string expectedResult)
     {
         var smart = GetFormatter();
         var culture = new CultureInfo("en-US");
@@ -282,23 +322,54 @@ public class PluralLocalizationFormatterTests
     }
 
     [Test]
-    public void Test_With_CustomPluralRuleProvider()
+    public void Use_CustomPluralRuleProvider()
     {
         var smart = GetFormatter();
-        var actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("de")), "{0:plural:Frau|Frauen}", new string[2], "more");
-        Assert.That(actualResult, Is.EqualTo("Frauen"));
 
-        actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[2], "more");
-        Assert.That(actualResult, Is.EqualTo("people"));
+        Assert.Multiple(() =>
+        {
+            // ** German **
+            var actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("de")),
+                "{0:plural:Frau|Frauen}", new string[2], "more");
+            Assert.That(actualResult, Is.EqualTo("Frauen"));
 
-        actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")), "{0:plural:person|people}", new string[1], "one");
-        Assert.That(actualResult, Is.EqualTo("person"));
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("de")),
+                "{0:plural:Frau|Frauen|einige Frauen|viele Frauen}", new string[4], "more");
+            Assert.That(actualResult, Is.EqualTo("viele Frauen"));
 
-        actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")), "{0:plural:une personne|deux personnes|plusieurs personnes}", new string[3], "several");
-        Assert.That(actualResult, Is.EqualTo("plusieurs personnes"));
+            // ** English **
 
-        actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")), "{0:plural:une personne|deux personnes|plusieurs personnes|beaucoup de personnes}", new string[3], "several");
-        Assert.That(actualResult, Is.EqualTo("beaucoup de personnes"));
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")),
+                "{0:plural:person|people}", new string[2], "more");
+            Assert.That(actualResult, Is.EqualTo("people"));
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("en")),
+                "{0:plural:person|people}", new string[1], "one");
+            Assert.That(actualResult, Is.EqualTo("person"));
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")),
+                "{0:plural:pas de personne|une personne|plusieurs personnes}", Array.Empty<string>(), "none");
+            Assert.That(actualResult, Is.EqualTo("pas de personne"));
+
+            // ** French **
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")),
+                "{0:plural:pas de personne|une personne|plusieurs personnes}", new string[1], "one");
+            Assert.That(actualResult, Is.EqualTo("une personne"));
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")),
+                "{0:plural:pas de personne|une personne|deux personnes}", new string[2], "two");
+            Assert.That(actualResult, Is.EqualTo("deux personnes"));
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")),
+                "{0:plural:pas de personne|une personne|deux personnes|plusieurs personnes}", new string[3], "several");
+            Assert.That(actualResult, Is.EqualTo("plusieurs personnes"));
+
+            actualResult = smart.Format(new CustomPluralRuleProvider(PluralRules.GetPluralRule("fr")),
+                "{0:plural:une personne|deux personnes|plusieurs personnes|beaucoup de personnes}", new string[3],
+                "many");
+            Assert.That(actualResult, Is.EqualTo("beaucoup de personnes"));
+        });
     }
 
     [TestCase("{0:plural:one|many} {1:plural:one|many} {2:plural:one|many}", "many one many")]
@@ -318,7 +389,10 @@ public class PluralLocalizationFormatterTests
     {
         var smart = GetFormatter();
         foreach (var number in new object[]
-                     { (long)123, (ulong)123, (short)123, (ushort)123, (int)123, (uint)123 })
+                 {
+                     (long)123, (ulong)123, (short)123, (ushort)123, (int)123, (uint)123,
+                     (long)-123, (short) -123, (int) -123
+                 })
         {
             Assert.That(smart.Format("{0:plural(en):zero|one|many}", number), Is.EqualTo("many"));
         }
@@ -362,5 +436,49 @@ public class PluralLocalizationFormatterTests
             
         var result = smart.Format(format, data);
         Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase(0, "nobody", "pas de personne")] // 0 is singular
+    [TestCase(1, "{0} person", "{0} personne")] // 1 is singular
+    [TestCase(2, "{0} people", "{0} personnes")] // 2 or more is plural
+    [TestCase(5, "a couple of people", "quelques personnes")]
+    [TestCase(15, "many people", "beaucoup de gens")]
+    [TestCase(50, "a lot of people", "une foule de personnes")]
+    public void Pluralization_With_Changed_Default_Rule_Delegate(int count, string rawExpectedEnglish, string rawExpectedFrench)
+    {
+        // Note: This test changes a default rule delegate *globally*.
+        //       It is not recommended, but possible.
+        PluralRules.IsoLangToDelegate["en"] = (value, wordsCount) =>
+        {
+            if (wordsCount != 6) return -1;
+
+            return Math.Abs(value) switch
+            {
+                <= 0 => 0,
+                > 0 and < 2 => 1,
+                >= 2 and < 3 => 2,
+                > 2 and < 10 => 3,
+                >= 10 and < 20 => 4,
+                >= 20 => 5
+            };
+        };
+        // Use the same rule delegate for English and French:
+        PluralRules.IsoLangToDelegate["fr"] = PluralRules.IsoLangToDelegate["en"];
+
+        var smart = GetFormatter();
+        var ciEnglish = CultureInfo.GetCultureInfo("en");
+        var ciFrench = CultureInfo.GetCultureInfo("fr");
+
+        var actualEnglish = smart.Format(ciEnglish, "{0:plural:nobody|{} person|{} people|a couple of people|many people|a lot of people}", count);
+        var actualFrench = smart.Format(ciFrench, "{0:plural:pas de personne|{} personne|{} personnes|quelques personnes|beaucoup de gens|une foule de personnes}", count);
+
+        // Restore default rule delegates:
+        PluralRules.RestoreDefault();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actualEnglish, Is.EqualTo(string.Format(ciEnglish, rawExpectedEnglish, count)));
+            Assert.That(actualFrench, Is.EqualTo(string.Format(ciFrench, rawExpectedFrench, count)));
+        });
     }
 }

--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -180,15 +180,16 @@ public class PluralLocalizationFormatterTests
         Assert.That(actual, Is.EqualTo(string.Format(ci, expected, count)));
     }
 
+    [TestCase(-1, "-")]
     [TestCase(0, "pas de personne")] // 0 is singular
     [TestCase(1, "une personne")] // 1 is singular
-    [TestCase(2, "deux personnes")] // 2 is plural
+    [TestCase(2, "{0} personnes")] // 2 is plural
     [TestCase(50, "{0} personnes")] // more than 2
     public void Test_French_4words(int count, string expected)
     {
         var smart = GetFormatter();
         var ci = CultureInfo.GetCultureInfo("fr");
-        var actual = smart.Format(ci, "{0:plural:pas de personne|une personne|deux personnes|{0} personnes}", count);
+        var actual = smart.Format(ci, "{0:plural:-|pas de personne|une personne|{0} personnes}", count);
 
         Assert.That(actual, Is.EqualTo(string.Format(ci, expected, count)));
     }

--- a/src/SmartFormat/Extensions/CustomPluralRuleProvider.cs
+++ b/src/SmartFormat/Extensions/CustomPluralRuleProvider.cs
@@ -1,0 +1,44 @@
+﻿//
+// Copyright SmartFormat Project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using SmartFormat.Utilities;
+
+namespace SmartFormat.Extensions;
+/// <summary>
+/// Use this class to provide custom plural rules to Smart.Format
+/// </summary>
+public class CustomPluralRuleProvider : IFormatProvider
+{
+    private readonly PluralRules.PluralRuleDelegate _pluralRule;
+
+    /// <summary>
+    /// Creates a new instance of a <see cref="CustomPluralRuleProvider"/>.
+    /// </summary>
+    /// <param name="pluralRule">The delegate for plural rules.</param>
+    public CustomPluralRuleProvider(PluralRules.PluralRuleDelegate pluralRule)
+    {
+        _pluralRule = pluralRule;
+    }
+
+    /// <summary>
+    /// Gets the format <see cref="object"/> for a <see cref="CustomPluralRuleProvider"/>.
+    /// </summary>
+    /// <param name="formatType"></param>
+    /// <returns>The format <see cref="object"/> for a <see cref="CustomPluralRuleProvider"/> or <see langword="null"/>.</returns>
+    public object? GetFormat(Type? formatType)
+    {
+        return formatType == typeof(CustomPluralRuleProvider) ? this : default;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="PluralRules.PluralRuleDelegate"/> of the current <see cref="CustomPluralRuleProvider"/> instance.
+    /// </summary>
+    /// <returns></returns>
+    public PluralRules.PluralRuleDelegate GetPluralRule()
+    {
+        return _pluralRule;
+    }
+}

--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -222,38 +222,3 @@ public class PluralLocalizationFormatter : IFormatter
     }
 }
 
-/// <summary>
-/// Use this class to provide custom plural rules to Smart.Format
-/// </summary>
-public class CustomPluralRuleProvider : IFormatProvider
-{
-    private readonly PluralRules.PluralRuleDelegate _pluralRule;
-
-    /// <summary>
-    /// Creates a new instance of a <see cref="CustomPluralRuleProvider"/>.
-    /// </summary>
-    /// <param name="pluralRule">The delegate for plural rules.</param>
-    public CustomPluralRuleProvider(PluralRules.PluralRuleDelegate pluralRule)
-    {
-        _pluralRule = pluralRule;
-    }
-
-    /// <summary>
-    /// Gets the format <see cref="object"/> for a <see cref="CustomPluralRuleProvider"/>.
-    /// </summary>
-    /// <param name="formatType"></param>
-    /// <returns>The format <see cref="object"/> for a <see cref="CustomPluralRuleProvider"/> or <see langword="null"/>.</returns>
-    public object? GetFormat(Type? formatType)
-    {
-        return formatType == typeof(CustomPluralRuleProvider) ? this : default;
-    }
-
-    /// <summary>
-    /// Gets the <see cref="PluralRules.PluralRuleDelegate"/> of the current <see cref="CustomPluralRuleProvider"/> instance.
-    /// </summary>
-    /// <returns></returns>
-    public PluralRules.PluralRuleDelegate GetPluralRule()
-    {
-        return _pluralRule;
-    }
-}

--- a/src/SmartFormat/Utilities/PluralRules.cs
+++ b/src/SmartFormat/Utilities/PluralRules.cs
@@ -228,7 +228,7 @@ public static class PluralRules
 
     private static PluralRuleDelegate DualFromZeroToTwo => (value, pluralWordsCount) =>
     {
-        if (pluralWordsCount == 2) return value < 2 ? 0 : 1;
+        if (pluralWordsCount == 2) return value is >= 0 and < 2 ? 0 : 1;
 
         if (pluralWordsCount == 3) return GetWordsCount3Value(value);
         
@@ -239,9 +239,9 @@ public static class PluralRules
 
     private static int GetWordsCount3Value(decimal n)
     {
-        return Math.Abs(n) switch
+        return n switch
         {
-            <=0 => 0,
+            0 => 0,
             > 0 and < 2 => 1,
             _ => 2
         };
@@ -249,11 +249,11 @@ public static class PluralRules
 
     private static int GetWordsCount4Value(decimal n)
     {
-        return Math.Abs(n) switch
+        return n switch
         {
-            <=0 => 0,
-            > 0 and < 2 => 1,
-            >= 2 and < 3 => 2,
+            < 0 => 0,
+            0 => 1,
+            > 0 and < 2 => 2,
             _ => 3
         };
     }

--- a/src/SmartFormat/Utilities/PluralRules.cs
+++ b/src/SmartFormat/Utilities/PluralRules.cs
@@ -243,7 +243,7 @@ public static class PluralRules
         {
             <=0 => 0,
             > 0 and < 2 => 1,
-            >= 2 => 2
+            _ => 2
         };
     }
 
@@ -254,7 +254,7 @@ public static class PluralRules
             <=0 => 0,
             > 0 and < 2 => 1,
             >= 2 and < 3 => 2,
-            > 2 => 3
+            _ => 3
         };
     }
         

--- a/src/SmartFormat/Utilities/PluralRules.cs
+++ b/src/SmartFormat/Utilities/PluralRules.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace SmartFormat.Utilities;
 #pragma warning disable S3776 // disable sonar cognitive complexity warnings
@@ -15,10 +16,7 @@ namespace SmartFormat.Utilities;
 /// </summary>
 public static class PluralRules
 {
-    /// <summary>
-    /// Holds the ISO language code as key, and the <see cref="PluralRuleDelegate"/> with the pluralization rule.
-    /// </summary>
-    public static Dictionary<string, PluralRuleDelegate> IsoLangToDelegate { get; } =
+    private static Dictionary<string, PluralRuleDelegate> DefaultLangToDelegate { get; } =
         new() {
             // Singular
             { "az", Singular }, // Azerbaijani
@@ -193,6 +191,22 @@ public static class PluralRules
             { "tzm", CentralMoroccoTamazight }
         };
 
+    /// <summary>
+    /// Holds the two-letter ISO language code as key, and the <see cref="PluralRuleDelegate"/> with the pluralization rule.
+    /// <para/>
+    /// Changing a value of this dictionary will change the pluralization rules globally. This is not recommended, but possible.
+    /// </summary>
+    public static Dictionary<string, PluralRuleDelegate> IsoLangToDelegate { get; private set; } =
+        new(DefaultLangToDelegate);
+
+    /// <summary>
+    /// Restores the default rules, e.g. after adding custom rules.
+    /// </summary>
+    public static void RestoreDefault()
+    {
+        IsoLangToDelegate = new Dictionary<string, PluralRuleDelegate>(DefaultLangToDelegate);
+    }
+
     private static PluralRuleDelegate Singular => (value, pluralWordsCount) => 0;
 
     private static PluralRuleDelegate DualOneOther => (value, pluralWordsCount) =>
@@ -217,7 +231,7 @@ public static class PluralRules
         if (pluralWordsCount == 2) return value < 2 ? 0 : 1;
 
         if (pluralWordsCount == 3) return GetWordsCount3Value(value);
-
+        
         if (pluralWordsCount == 4) return GetWordsCount4Value(value);
 
         return -1;
@@ -225,36 +239,36 @@ public static class PluralRules
 
     private static int GetWordsCount3Value(decimal n)
     {
-        return n switch {
-            0 => 0,
+        return Math.Abs(n) switch
+        {
+            <=0 => 0,
             > 0 and < 2 => 1,
-            > 2 => 2,
-            _ => -1
+            >= 2 => 2
         };
     }
 
     private static int GetWordsCount4Value(decimal n)
     {
-        return n switch {
-            < 0 => 0,
-            0 => 1,
-            > 0 and < 2 => 2,
-            > 2 => 3,
-            _ => -1
+        return Math.Abs(n) switch
+        {
+            <=0 => 0,
+            > 0 and < 2 => 1,
+            >= 2 and < 3 => 2,
+            > 2 => 3
         };
     }
         
     private static PluralRuleDelegate TripleOneTwoOther => (value, pluralWordsCount) => value == 1 ? 0 : value == 2 ? 1 : 2; // Triple: one (n == 1), two (n == 2), other
     private static PluralRuleDelegate RussianSerboCroatian => (value, pluralWordsCount) =>
         value % 10 == 1 && value % 100 != 11 ? 0 : // one
-        (value % 10).Between(2, 4) && !(value % 100).Between(12, 14) ? 1 : // few
+        (value % 10).BetweenWithoutFraction(2, 4) && !(value % 100).BetweenWithoutFraction(12, 14) ? 1 : // few
         2; // Russian & Serbo-Croatian
     private static PluralRuleDelegate Arabic => (value, pluralWordsCount) =>
         value == 0 ? 0 : // zero
         value == 1 ? 1 : // one
         value == 2 ? 2 : // two
-        (value % 100).Between(3, 10) ? 3 : // few
-        (value % 100).Between(11, 99) ? 4 : // many
+        (value % 100).BetweenWithoutFraction(3, 10) ? 3 : // few
+        (value % 100).BetweenWithoutFraction(11, 99) ? 4 : // many
         5; // other
     private static PluralRuleDelegate Breton => (value, pluralWordsCount) =>
         value switch
@@ -269,7 +283,7 @@ public static class PluralRules
     private static PluralRuleDelegate Czech => (value, pluralWordsCount) =>
         value == 0 ? 0 : // zero
         value == 1 ? 1 : // one
-        value.Between(2, 4) ? 2 : // few
+        value.BetweenWithoutFraction(2, 4) ? 2 : // few
         value % 1 == 0 ? 3 : // many
         4;  // other
 
@@ -284,17 +298,20 @@ public static class PluralRules
             _ => 5  // other
         };
     private static PluralRuleDelegate Manx => (value, pluralWordsCount) =>
-        (value % 10).Between(1, 2) || value % 20 == 0
+        (value % 10).BetweenWithoutFraction(1, 2) || value % 20 == 0
             ? 0
             : // one
             1;
     private static PluralRuleDelegate Langi => (value, pluralWordsCount) =>
-        value == 0 ? 0 : // zero
-        value is > 0 and < 2 ? 1 : // one
-        2;
+        value switch
+        {
+            0 => 0,
+            > 0 and < 2 => 1,
+            _ => 2
+        };
     private static PluralRuleDelegate Lithuanian => (value, pluralWordsCount) =>
-        value % 10 == 1 && !(value % 100).Between(11, 19) ? 0 : // one
-        (value % 10).Between(2, 9) && !(value % 100).Between(11, 19) ? 1 : // few
+        value % 10 == 1 && !(value % 100).BetweenWithoutFraction(11, 19) ? 0 : // one
+        (value % 10).BetweenWithoutFraction(2, 9) && !(value % 100).BetweenWithoutFraction(11, 19) ? 1 : // few
         2;
     private static PluralRuleDelegate Latvian => (value, pluralWordsCount) =>
         value == 0 ? 0 : // zero
@@ -307,37 +324,37 @@ public static class PluralRules
             1;
     private static PluralRuleDelegate Moldavian => (value, pluralWordsCount) =>
         value == 1 ? 0 : // one
-        value == 0 || value != 1 && (value % 100).Between(1, 19) ? 1 : // few
+        value == 0 || value != 1 && (value % 100).BetweenWithoutFraction(1, 19) ? 1 : // few
         2;
     private static PluralRuleDelegate Maltese => (value, pluralWordsCount) =>
         value == 1 ? 0 : // one
-        value == 0 || (value % 100).Between(2, 10) ? 1 : // few
-        (value % 100).Between(11, 19) ? 2 : // many
+        value == 0 || (value % 100).BetweenWithoutFraction(2, 10) ? 1 : // few
+        (value % 100).BetweenWithoutFraction(11, 19) ? 2 : // many
         3;
     private static PluralRuleDelegate Polish => (value, pluralWordsCount) =>
         value == 1 ? 0 : // one
-        (value % 10).Between(2, 4) && !(value % 100).Between(12, 14) ? 1 : // few
-        (value % 10).Between(0, 1) || (value % 10).Between(5, 9) || (value % 100).Between(12, 14) ? 2 : // many
+        (value % 10).BetweenWithoutFraction(2, 4) && !(value % 100).BetweenWithoutFraction(12, 14) ? 1 : // few
+        (value % 10).BetweenWithoutFraction(0, 1) || (value % 10).BetweenWithoutFraction(5, 9) || (value % 100).BetweenWithoutFraction(12, 14) ? 2 : // many
         3;
     private static PluralRuleDelegate Romanian => (value, pluralWordsCount) =>
         value == 1 ? 0 : // one
-        value == 0 || (value % 100).Between(1, 19) ? 1 : // few
+        value == 0 || (value % 100).BetweenWithoutFraction(1, 19) ? 1 : // few
         2;
     private static PluralRuleDelegate Tachelhit => (value, pluralWordsCount) =>
         value >= 0 && value <= 1 ? 0 : // one
-        value.Between(2, 10) ? 1 : // few
+        value.BetweenWithoutFraction(2, 10) ? 1 : // few
         2;
     private static PluralRuleDelegate Slovak => (value, pluralWordsCount) =>
         value == 1 ? 0 : // one
-        value.Between(2, 4) ? 1 : // few
+        value.BetweenWithoutFraction(2, 4) ? 1 : // few
         2;
     private static PluralRuleDelegate Slovenian => (value, pluralWordsCount) =>
         value % 100 == 1 ? 0 : // one
         value % 100 == 2 ? 1 : // two
-        (value % 100).Between(3, 4) ? 2 : // few
+        (value % 100).BetweenWithoutFraction(3, 4) ? 2 : // few
         3;
     private static PluralRuleDelegate CentralMoroccoTamazight => (value, pluralWordsCount) =>
-        value.Between(0, 1) || value.Between(11, 99)
+        value.BetweenWithoutFraction(0, 1) || value.BetweenWithoutFraction(11, 99)
             ? 0
             : // one
             1;
@@ -359,8 +376,8 @@ public static class PluralRules
     /// </remarks>
     public static PluralRuleDelegate GetPluralRule(string? twoLetterIsoLanguageName)
     {
-        if (twoLetterIsoLanguageName != null && IsoLangToDelegate.ContainsKey(twoLetterIsoLanguageName)) 
-            return IsoLangToDelegate[twoLetterIsoLanguageName];
+        if (twoLetterIsoLanguageName != null && IsoLangToDelegate.TryGetValue(twoLetterIsoLanguageName, out var rule)) 
+            return rule;
 
         throw new ArgumentException($"{nameof(IsoLangToDelegate)} not found for {twoLetterIsoLanguageName ?? "'null'"}", nameof(twoLetterIsoLanguageName));
     }
@@ -368,7 +385,7 @@ public static class PluralRules
     /// <summary>
     /// Returns <see langword="true"/> if the value is inclusively between the min and max and has no fraction.
     /// </summary>
-    private static bool Between(this decimal value, decimal min, decimal max)
+    private static bool BetweenWithoutFraction(this decimal value, decimal min, decimal max)
     {
         return value % 1 == 0 && value >= min && value <= max;
     }


### PR DESCRIPTION
PluralRule for DualFromZeroToTwo: Does not cover value of 2

The `Dictionary<string, PluralRuleDelegate> IsoLangToDelegate` is backed by a default dictionary. It can be restored with `PluralRules.RestoreDefault()` if one of the delegates was changed. Both has global effect.

Extract class `CustomPluralRuleProvider` to its own file

`PluralRuleDelegate DualFromZeroToTwo`:
* with 3 words, the index is for counts of 0, > 0 and < 2, more than 2
* with 4 words, the index is for counts of 0, > 0 and < 2,  >= 2 and < 3, more than 3

Add unit tests