### PR TITLE
Change all public types in namespace Cysharp.Text to internal

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -13,8 +13,8 @@ jobs:
     # (PRs from forks can't access secrets other than secrets.GITHUB_TOKEN for security reasons)
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
-      version: '3.3.1'
-      versionFile: '3.3.1'
+      version: '3.3.2'
+      versionFile: '3.3.2'
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
       - ps: dotnet restore SmartFormat.sln --verbosity quiet
       - ps: dotnet add .\SmartFormat.Tests\SmartFormat.Tests.csproj package AltCover
       - ps: |
-          $version = "3.3.1"
+          $version = "3.3.2"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) SmartFormat Project</Copyright>
         <RepositoryUrl>https://github.com/axuno/SmartFormat.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>3.3.1</Version>
-        <FileVersion>3.3.1</FileVersion>
+        <Version>3.3.2</Version>
+        <FileVersion>3.3.2</FileVersion>
         <AssemblyVersion>3.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/SmartFormat.ZString.Tests/CysharpText.cs
+++ b/src/SmartFormat.ZString.Tests/CysharpText.cs
@@ -1,0 +1,34 @@
+﻿//
+// Copyright SmartFormat Project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using NUnit.Framework;
+
+namespace SmartFormat.ZString.Tests;
+
+[TestFixture]
+public class CysharpText
+{
+    /// <summary>
+    /// To stop namespace collision with Cysharp.Text nuget package,
+    /// change all public types in namespace Cysharp.Text to internal.
+    /// This can easily happen when Cysharp.Text is updated in the SmartFormat.ZString project.
+    /// Using https://github.com/zzzprojects/findandreplace on command line, so we can automate this step:
+    /// "fnr.exe" --cl --dir "SmartFormat.ZString\repo\src\ZString" --fileMask "*.cs,*.tt" --includeSubDirectories --caseSensitive --useRegEx --find "public (?=.*(class |struct |enum |interface |delegate ))" --replace "internal "
+    /// </summary>
+    [Test]
+    public void Classes_Of_Cysharp_Text_Namespace_Should_Be_Internal()
+    {
+        // If this tests fails, you need to run the above command line
+        // to change all public types in namespace Cysharp.Text to internal
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeof(Cysharp.Text.Utf16ValueStringBuilder).IsPublic, Is.False);
+            Assert.That(typeof(Cysharp.Text.Utf8ValueStringBuilder).IsPublic, Is.False);
+            Assert.That(typeof(Cysharp.Text.ZString).IsPublic, Is.False);
+            Assert.That(typeof(Cysharp.Text.FormatParser).IsPublic, Is.False);
+            Assert.That(typeof(System.HexConverter).IsPublic, Is.False);
+        });
+    }
+}

--- a/src/SmartFormat.ZString.Tests/SmartFormat.ZString.Tests.csproj
+++ b/src/SmartFormat.ZString.Tests/SmartFormat.ZString.Tests.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Unit tests for SmartFormat.ZString</Description>
+        <AssemblyTitle>SmartFormat.ZString.Tests</AssemblyTitle>
+        <Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <AssemblyName>SmartFormat.ZString.Tests</AssemblyName>
+        <AssemblyOriginatorKeyFile>../SmartFormat/SmartFormat.snk</AssemblyOriginatorKeyFile>
+        <DelaySign>false</DelaySign>
+        <SignAssembly>true</SignAssembly>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NUnit" Version="4.0.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <NoWarn>$(NoWarn);CA1861</NoWarn>
+        <WarningLevel>4</WarningLevel>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <NoWarn>$(NoWarn);CA1861</NoWarn>
+        <WarningLevel>4</WarningLevel>
+        <DefineConstants>RELEASE</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SmartFormat.ZString\SmartFormat.ZString.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/SmartFormat.ZString/SmartFormat.ZString.csproj
+++ b/src/SmartFormat.ZString/SmartFormat.ZString.csproj
@@ -79,4 +79,10 @@
         <PackageReference Include="System.Memory" Version="4.5.4" />
     </ItemGroup>
 
+    <ItemGroup>
+	    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+		    <_Parameter1>SmartFormat.ZString.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a1cdb8ba81e1a00f0f9509a8f0c896e0de0da6875652fffd44fb867e6b78fd78c31c6fdb07544b2ae53ed4b56daa90333d32ac14387f7f68d39165da8f99b8c294c1cee1bcc4bbcbe2dd73879824b53708837f425e2bf5c7d2cf868de9548c44871888bf9db5cb425064dda4b17134f8e3b52e1f686315a1832043c7b58fb0ac</_Parameter1>
+	    </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/src/SmartFormat.ZString/ZStringWriter.cs
+++ b/src/SmartFormat.ZString/ZStringWriter.cs
@@ -27,13 +27,15 @@ public sealed class ZStringWriter : TextWriter
 {
     private Utf16ValueStringBuilder sb;
     private bool isOpen;
-    private UnicodeEncoding encoding;
+    private UnicodeEncoding encoding = null!;
 
     /// <summary>
     /// Creates a new instance using <see cref="CultureInfo.CurrentCulture"/> as format provider.
     /// </summary>
     public ZStringWriter() : this(CultureInfo.CurrentCulture)
     {
+        sb = Cysharp.Text.ZString.CreateStringBuilder();
+        isOpen = true;
     }
 
     /// <summary>
@@ -41,8 +43,6 @@ public sealed class ZStringWriter : TextWriter
     /// </summary>
     public ZStringWriter(IFormatProvider formatProvider) : base(formatProvider)
     {
-        sb = Cysharp.Text.ZString.CreateStringBuilder();
-        isOpen = true;
     }
 
     /// <summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/FormatParser.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/FormatParser.cs
@@ -7,7 +7,7 @@ namespace Cysharp.Text
     {
         // {index[,alignment][:formatString]}
 
-        public readonly ref struct ParseResult
+        internal readonly ref struct ParseResult
         {
             public readonly int Index;
             public readonly ReadOnlySpan<char> FormatString;

--- a/src/SmartFormat.ZString/repo/src/ZString/IResettableBufferWriter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/IResettableBufferWriter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Cysharp.Text
 {
-    public interface IResettableBufferWriter<T> : IBufferWriter<T>
+    internal interface IResettableBufferWriter<T> : IBufferWriter<T>
     {
         void Reset();
     }

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/BitOperations.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/BitOperations.cs
@@ -15,7 +15,7 @@ namespace System.Numerics
     /// The methods use hardware intrinsics when available on the underlying platform,
     /// otherwise they use optimized software fallbacks.
     /// </summary>
-    public static class BitOperations
+    internal static class BitOperations
     {
         // C# no-alloc optimization that directly wraps the data section of the dll (similar to string constants)
         // https://github.com/dotnet/roslyn/pull/24621

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/HexConverter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/HexConverter.cs
@@ -8,7 +8,7 @@ namespace System
 {
     internal static class HexConverter
     {
-        public enum Casing : uint
+        internal enum Casing : uint
         {
             // Output [ '0' .. '9' ] and [ 'A' .. 'F' ].
             Upper = 0,

--- a/src/SmartFormat.ZString/repo/src/ZString/Number/Number.NumberToFloatingPointBits.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Number/Number.NumberToFloatingPointBits.cs
@@ -15,7 +15,7 @@ namespace System
             return *((int*)&value);
         }
 
-        public readonly struct FloatingPointInfo
+        internal readonly struct FloatingPointInfo
         {
             public static readonly FloatingPointInfo Double = new FloatingPointInfo(
                 denormalMantissaBits: 52,

--- a/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public sealed partial class Utf16PreparedFormat<T1>
+    internal sealed partial class Utf16PreparedFormat<T1>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -69,7 +69,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2>
+    internal sealed partial class Utf16PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -139,7 +139,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -214,7 +214,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -294,7 +294,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -379,7 +379,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -469,7 +469,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -564,7 +564,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -664,7 +664,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -769,7 +769,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -879,7 +879,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -994,7 +994,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1114,7 +1114,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1239,7 +1239,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1369,7 +1369,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1504,7 +1504,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    internal sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1644,7 +1644,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1>
+    internal sealed partial class Utf8PreparedFormat<T1>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1710,7 +1710,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2>
+    internal sealed partial class Utf8PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1781,7 +1781,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1857,7 +1857,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -1938,7 +1938,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2024,7 +2024,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2115,7 +2115,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2211,7 +2211,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2312,7 +2312,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2418,7 +2418,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2529,7 +2529,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2645,7 +2645,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2766,7 +2766,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -2892,7 +2892,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -3023,7 +3023,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
         public int MinSize { get; }
@@ -3159,7 +3159,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    internal sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
         public int MinSize { get; }

--- a/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/PreparedFormat.tt
@@ -13,7 +13,7 @@ namespace Cysharp.Text
 {
 <# foreach(var utf in utfTypes) { var isUtf16 = (utf == "Utf16"); #>
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
-    public sealed partial class <#= utf #>PreparedFormat<<#= CreateTypeArgument(i) #>>
+    internal sealed partial class <#= utf #>PreparedFormat<<#= CreateTypeArgument(i) #>>
     {
         public string FormatString { get; }
         public int MinSize { get; }

--- a/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.
@@ -209,7 +209,7 @@ namespace Cysharp.Text
             }
         }
     }
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.

--- a/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/StringBuilder.AppendJoin.tt
@@ -15,7 +15,7 @@ using System.Runtime.CompilerServices;
 namespace Cysharp.Text
 {
 <# foreach(var utf in utfTypes) { #>
-    public partial struct <#= utf #>ValueStringBuilder
+    internal partial struct <#= utf #>ValueStringBuilder
     {
         /// <summary>
         /// Concatenates the string representations of the elements in the provided array of objects, using the specified char separator between each member, then appends the result to the current instance of the string builder.

--- a/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.cs
@@ -4,7 +4,7 @@ using TMPro;
 
 namespace Cysharp.Text
 {
-    public static partial class TextMeshProExtensions
+    internal static partial class TextMeshProExtensions
     {
         public static void SetText<T>(this TMP_Text text, T arg0)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Unity/TextMeshProExtensions.tt
@@ -27,7 +27,7 @@ using TMPro;
 
 namespace Cysharp.Text
 {
-    public static partial class TextMeshProExtensions
+    internal static partial class TextMeshProExtensions
     {
         public static void SetText<T>(this TMP_Text text, T arg0)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
@@ -9,7 +9,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         static object? CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
@@ -35,7 +35,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16/Utf16ValueStringBuilder.SpanFormattableAppend.tt
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder
+    internal partial struct Utf16ValueStringBuilder
     {
 <# foreach(var t in spanFormattables) { #>
         /// <summary>Appends the string representation of a specified value to this instance.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf16ValueStringBuilder.cs
@@ -5,9 +5,9 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf16ValueStringBuilder : IDisposable, IBufferWriter<char>, IResettableBufferWriter<char>
+    internal partial struct Utf16ValueStringBuilder : IDisposable, IBufferWriter<char>, IResettableBufferWriter<char>
     {
-        public delegate bool TryFormat<T>(T value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format);
+        internal delegate bool TryFormat<T>(T value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format);
 
         const int ThreadStaticBufferSize = 31111;
         const int DefaultBufferSize = 32768; // use 32K default buffer.
@@ -709,7 +709,7 @@ namespace Cysharp.Text
             RegisterTryFormat<T?>(CreateNullableFormatter<T>());
         }
 
-        public static class FormatterCache<T>
+        internal static class FormatterCache<T>
         {
             public static TryFormat<T> TryFormatDelegate;
             static FormatterCache()

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
@@ -10,7 +10,7 @@ using System.Buffers;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
@@ -4,7 +4,7 @@ using System.Buffers.Text;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         static object? CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
@@ -11,7 +11,7 @@ using System.Buffers.Text;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         static object CreateFormatter(Type type)
         {

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder
+    internal partial struct Utf8ValueStringBuilder
     {
 <# foreach(var t in utf8spanFormattables) { #>
         /// <summary>Appends the string representation of a specified value to this instance.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/Utf8ValueStringBuilder.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace Cysharp.Text
 {
-    public partial struct Utf8ValueStringBuilder : IDisposable, IBufferWriter<byte>, IResettableBufferWriter<byte>
+    internal partial struct Utf8ValueStringBuilder : IDisposable, IBufferWriter<byte>, IResettableBufferWriter<byte>
     {
-        public delegate bool TryFormat<T>(T value, Span<byte> destination, out int written, StandardFormat format);
+        internal delegate bool TryFormat<T>(T value, Span<byte> destination, out int written, StandardFormat format);
 
         const int ThreadStaticBufferSize = 64444;
         const int DefaultBufferSize = 65536; // use 64K default buffer.
@@ -495,7 +495,7 @@ namespace Cysharp.Text
             RegisterTryFormat<T?>(CreateNullableFormatter<T>());
         }
 
-        public static class FormatterCache<T>
+        internal static class FormatterCache<T>
         {
             public static TryFormat<T> TryFormatDelegate;
             static FormatterCache()

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Concatenates the string representation of some specified objects.</summary>
         public static string Concat<T1>(T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Concat.tt
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Concatenates the string representation of some specified objects.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Format.tt
@@ -10,7 +10,7 @@ using System;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.cs
@@ -2,7 +2,7 @@
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Prepare string format to avoid parse template in each operation.</summary>
         public static Utf16PreparedFormat<T1> PrepareUtf16<T1>(string format)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Prepare.tt
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Prepare string format to avoid parse template in each operation.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.cs
@@ -6,7 +6,7 @@ using static Cysharp.Text.Utf8ValueStringBuilder;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1>(IBufferWriter<byte> bufferWriter, string format, T1 arg1)

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.tt
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.Utf8Format.tt
@@ -13,7 +13,7 @@ using static Cysharp.Text.Utf8ValueStringBuilder;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
 <# for(var i = 1; i <= TypeParamMax; i++) { #>
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>

--- a/src/SmartFormat.ZString/repo/src/ZString/ZString.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZString.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Cysharp.Text
 {
-    public static partial class ZString
+    internal static partial class ZString
     {
         static Encoding UTF8NoBom = new UTF8Encoding(false);
 

--- a/src/SmartFormat.ZString/repo/src/ZString/ZStringWriter.cs
+++ b/src/SmartFormat.ZString/repo/src/ZString/ZStringWriter.cs
@@ -13,7 +13,7 @@ namespace Cysharp.Text
     /// <remarks>
     /// It's important to make sure the writer is always properly disposed.
     /// </remarks>
-    public sealed class ZStringWriter : TextWriter
+    internal sealed class ZStringWriter : TextWriter
     {
         private Utf16ValueStringBuilder sb;
         private bool isOpen;

--- a/src/SmartFormat.sln
+++ b/src/SmartFormat.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartFormat.Net", "SmartFor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartFormat.Extensions.Time", "SmartFormat.Extensions.Time\SmartFormat.Extensions.Time.csproj", "{62553041-4606-47FC-B44E-8D6D51F23E22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartFormat.ZString.Tests", "SmartFormat.ZString.Tests\SmartFormat.ZString.Tests.csproj", "{72652F62-537C-4C57-9D2A-4FD6C4BF8425}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -121,6 +123,14 @@ Global
 		{62553041-4606-47FC-B44E-8D6D51F23E22}.Release|Any CPU.Build.0 = Release|Any CPU
 		{62553041-4606-47FC-B44E-8D6D51F23E22}.Release|x86.ActiveCfg = Release|Any CPU
 		{62553041-4606-47FC-B44E-8D6D51F23E22}.Release|x86.Build.0 = Release|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Debug|x86.Build.0 = Debug|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Release|x86.ActiveCfg = Release|Any CPU
+		{72652F62-537C-4C57-9D2A-4FD6C4BF8425}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Regression caused by https://github.com/axuno/SmartFormat/pull/368
* Stop namespace collision with Cysharp.ZString nuget package (again) 
   * Affects: class, struct, interface, delegate, enum
   * using https://github.com/zzzprojects/findandreplace on command line, so we can automate this step:
`"fnr.exe" --cl --dir "SmartFormat.ZString\repo\src\ZString" --fileMask "*.cs,*.tt" --includeSubDirectories --caseSensitive --useRegEx --find "public (?=.*(class |struct |enum |interface |delegate ))" --replace "internal "`
* Add a unit test to get an alert when Cysharp.Text objects are public

Bump version to v3.3.2