### PR TITLE
Abort formatting exception

### DIFF
--- a/src/SmartFormat/Core/Formatting/AbortFormattingException.cs
+++ b/src/SmartFormat/Core/Formatting/AbortFormattingException.cs
@@ -1,0 +1,34 @@
+﻿// 
+// Copyright SmartFormat Project maintainers and contributors.
+// Licensed under the MIT license.
+
+using System;
+using SmartFormat.Core.Extensions;
+
+namespace SmartFormat.Core.Formatting;
+
+/// <summary>
+/// An exception designed to halt further processing for a specific format item.
+/// This exception can be raised from an <see cref="ISource"/> to prevent additional processing,
+/// particularly in scenarios where the data's state is not yet prepared or deemed valid.
+/// </summary>
+[Serializable]
+public class AbortFormattingException : Exception
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="AbortFormattingException"/>.
+    /// </summary>
+    /// <param name="text">Optional text to be used in the output string.</param>
+    public AbortFormattingException(string text)
+    {
+        Text = text;
+    }
+
+    ///<inheritdoc/>
+    public AbortFormattingException() { }
+
+    /// <summary>
+    /// A message to be used in the output string.
+    /// </summary>
+    public string? Text { get; }
+}

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -387,6 +387,12 @@ public class SmartFormatter
             {
                 EvaluateSelectors(childFormattingInfo);
             }
+            catch (AbortFormattingException ex)
+            {
+                if (ex.Text != null)
+                    formattingInfo.Write(ex.Text);
+                continue;
+            }
             catch (Exception ex)
             {
                 // An error occurred while evaluation selectors


### PR DESCRIPTION
This solution addresses the issue I outlined in the GitHub discussion (https://github.com/axuno/SmartFormat/discussions/373). In scenarios where the data from a custom source may be invalid, it becomes necessary to prevent continued processing of the string, and halt any further sources, and formatters without necessarily generating an error. This is particularly useful when dealing with optional sources that may not always be used or ready yet.

This adds an exception named `AbortFormattingException`. When this exception is encountered during the processing of the string, it serves as a signal to cease any further processing. Additionally, the exception can optionally include text that will be inserted instead of proceeding with the regular formatting.