### PR TITLE
Exclude ZString wrappers from coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,5 +64,5 @@ for:
       - dotnet add ./SmartFormat.Tests/SmartFormat.Tests.csproj package AltCover
       - dotnet build SmartFormat.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
-      - dotnet test --no-build --framework net6.0 SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|SmartFormat.ZString|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - dotnet test --no-build --framework net6.0 SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|NUnit3.TestAdapter" /p:AltCoverTypeFilter="SmartFormat.ZString.ZStringBuilder|SmartFormat.ZString.ZStringWriter" /p:AltCoverLineCover="true"
       - bash <(curl -s https://codecov.io/bash) -f ./SmartFormat.Tests/coverage.net6.0.xml -n net6.0linux


### PR DESCRIPTION
Exclude wrappers `SmartFormat.ZString.ZStringBuilder`and `SmartFormat.ZString.ZStringWriter` from coverage analysis