### PR TITLE
Exclude ZString wrappers from code coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ for:
           }
     test_script:
       - cmd: nuget install Appveyor.TestLogger
-      - cmd: dotnet test --framework net6.0 --test-adapter-path:. --logger:Appveyor SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|SmartFormat.ZString|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - cmd: dotnet test --framework net6.0 SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|NUnit3.TestAdapter" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="true"
       - cmd: nuget install codecov -excludeversion
       - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\SmartFormat.Tests\coverage.net6.0.xml" -n net6.0win
     artifacts:
@@ -64,5 +64,5 @@ for:
       - dotnet add ./SmartFormat.Tests/SmartFormat.Tests.csproj package AltCover
       - dotnet build SmartFormat.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
-      - dotnet test --no-build --framework net6.0 SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|SmartFormat.ZString|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - dotnet test --no-build --framework net6.0 SmartFormat.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="..\SmartFormat\SmartFormat.snk" /p:AltCoverAssemblyExcludeFilter="SmartFormat.Tests|NUnit3.TestAdapter" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="true"
       - bash <(curl -s https://codecov.io/bash) -f ./SmartFormat.Tests/coverage.net6.0.xml -n net6.0linux

--- a/src/SmartFormat/ZString/ZStringBuilder.cs
+++ b/src/SmartFormat/ZString/ZStringBuilder.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices.ComTypes;
 using Cysharp.Text;
 
 namespace SmartFormat.ZString;
@@ -18,6 +20,7 @@ namespace SmartFormat.ZString;
 /// We cannot add/get <see cref="ZStringBuilder"/> into/from a list or stack,
 /// because it contains a value type <see langword="struct"/> <see cref="Utf16ValueStringBuilder"/>.
 /// </remarks>
+[ExcludeFromCodeCoverage]
 public class ZStringBuilder : IDisposable
 {
     /**********************************

--- a/src/SmartFormat/ZString/ZStringWriter.cs
+++ b/src/SmartFormat/ZString/ZStringWriter.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -21,6 +22,7 @@ namespace SmartFormat.ZString;
 /// <remarks>
 /// It's important to make sure the writer is always properly disposed.
 /// </remarks>
+[ExcludeFromCodeCoverage]
 public sealed class ZStringWriter : TextWriter
 {
     private readonly Cysharp.Text.ZStringWriter _zw;


### PR DESCRIPTION
* Flag `ZStringBuilder` and `ZStringWriter`with `[ExcludeFromCodeCoverage]`
* Add AltCoverAttributeFilter="ExcludeFromCodeCoverage" in CI tests