### PR TITLE
feat: Add net8.0 as a target framework

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -17,22 +17,22 @@ jobs:
       versionFile: '3.3.2'
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
@@ -61,7 +61,7 @@ jobs:
           echo "Packing Version: ${{ env.version }}, File Version: ${{ env.versionFile }}"
           dotnet pack ./src/SmartFormat.Deploy.sln /verbosity:minimal --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:PackageOutputPath=${{ github.workspace }}/artifacts /p:Version=${{ env.version }} /p:FileVersion=${{ env.versionFile }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Packages_${{ env.version }}
           path: ${{ github.workspace }}/artifacts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   - job_name: windows
     appveyor_build_worker_image: Visual Studio 2022
   - job_name: linux
-    appveyor_build_worker_image: Ubuntu
+    appveyor_build_worker_image: Ubuntu2204
 matrix:
   fast_finish: true
 

--- a/src/Demo/Sample Extensions/RTFOutput.cs
+++ b/src/Demo/Sample Extensions/RTFOutput.cs
@@ -64,11 +64,7 @@ public class RTFOutput : IOutput
     ///<inheritdoc/>
     public void Write(ZStringBuilder stringBuilder, IFormattingInfo? formattingInfo)
     {
-#if NETSTANDARD2_1
-            output.Append(stringBuilder.AsSpan());
-#else
         output.Append(stringBuilder.ToString());
-#endif
     }
         
     public override string ToString()

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
         <AnalysisModeSecurity>All</AnalysisModeSecurity>
         <AnalysisLevel>latest</AnalysisLevel>
         <Features>strict</Features>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net8.0</TargetFrameworks>
         <PackageReleaseNotes>Please see release notes on GitHub:
 https://github.com/axuno/SmartFormat/releases/
         </PackageReleaseNotes>

--- a/src/Performance/Performance.csproj
+++ b/src/Performance/Performance.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Performance_v27/Performance_v27.csproj
+++ b/src/Performance_v27/Performance_v27.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageReference Include="SmartFormat.NET" Version="2.7.0" />
   </ItemGroup>
 

--- a/src/SmartFormat.Extensions.Newtonsoft.Json/SmartFormat.Extensions.Newtonsoft.Json.csproj
+++ b/src/SmartFormat.Extensions.Newtonsoft.Json/SmartFormat.Extensions.Newtonsoft.Json.csproj
@@ -14,7 +14,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -24,7 +24,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat.Extensions.System.Text.Json/SmartFormat.Extensions.System.Text.Json.csproj
+++ b/src/SmartFormat.Extensions.System.Text.Json/SmartFormat.Extensions.System.Text.Json.csproj
@@ -13,8 +13,8 @@ It uses extensions to provide named placeholders, localization, pluralization, g
         <PackageTags>string-format stringformat template templating string-composition smartformat smart-format netstandard netcore netframework csharp c-sharp</PackageTags>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
-      <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
+        <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -24,7 +24,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat.Extensions.Time/SmartFormat.Extensions.Time.csproj
+++ b/src/SmartFormat.Extensions.Time/SmartFormat.Extensions.Time.csproj
@@ -20,7 +20,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat.Extensions.Xml/SmartFormat.Extensions.Xml.csproj
+++ b/src/SmartFormat.Extensions.Xml/SmartFormat.Extensions.Xml.csproj
@@ -20,7 +20,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat.Net/SmartFormat.Net.csproj
+++ b/src/SmartFormat.Net/SmartFormat.Net.csproj
@@ -20,7 +20,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -4,7 +4,7 @@
         <Description>Unit tests for SmartFormat</Description>
         <AssemblyTitle>SmartFormat.Test</AssemblyTitle>
         <Authors>axuno gGmbH, Scott Rippey, Bernhard Millauer and other contributors.</Authors>
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net60</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AssemblyName>SmartFormat.Tests</AssemblyName>
@@ -15,9 +15,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="NUnit" Version="4.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SmartFormat/Core/Formatting/FormattingException.cs
+++ b/src/SmartFormat/Core/Formatting/FormattingException.cs
@@ -42,6 +42,7 @@ public class FormattingException : Exception
     }
 
     ///<inheritdoc/>
+    [Obsolete("This API supports obsolete formatter-based serialization. It will be removed in version 4.")]
     protected FormattingException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context)

--- a/src/SmartFormat/Core/Output/StringOutput.cs
+++ b/src/SmartFormat/Core/Output/StringOutput.cs
@@ -64,8 +64,8 @@ public class StringOutput : IOutput
     /// <param name="formattingInfo">This parameter from <see cref="IOutput"/> will not be used here.</param>
     public void Write(ReadOnlySpan<char> text, IFormattingInfo? formattingInfo = null)
     {
-#if NETSTANDARD2_1
-            _output.Append(text);
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        _output.Append(text);
 #else
         _output.Append(text.ToString());
 #endif
@@ -74,8 +74,8 @@ public class StringOutput : IOutput
     ///<inheritdoc/>
     public void Write(ZStringBuilder stringBuilder, IFormattingInfo? formattingInfo = null)
     {
-#if NETSTANDARD2_1
-            _output.Append(stringBuilder.AsSpan());
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        _output.Append(stringBuilder.AsSpan());
 #else
         _output.Append(stringBuilder.ToString());
 #endif

--- a/src/SmartFormat/Core/Output/TextWriterOutput.cs
+++ b/src/SmartFormat/Core/Output/TextWriterOutput.cs
@@ -37,8 +37,8 @@ public class TextWriterOutput : IOutput
     ///<inheritdoc/>
     public void Write(ReadOnlySpan<char> text, IFormattingInfo? formattingInfo = null)
     {
-#if NETSTANDARD2_1
-            Output.Write(text);
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        Output.Write(text);
 #else
         Output.Write(text.ToString());
 #endif
@@ -47,8 +47,8 @@ public class TextWriterOutput : IOutput
     ///<inheritdoc/>
     public void Write(ZStringBuilder stringBuilder, IFormattingInfo? formattingInfo = null)
     {
-#if NETSTANDARD2_1
-            Output.Write(stringBuilder.AsSpan());
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        Output.Write(stringBuilder.AsSpan());
 #else
         Output.Write(stringBuilder.ToString());
 #endif

--- a/src/SmartFormat/Core/Parsing/EscapedLiteral.cs
+++ b/src/SmartFormat/Core/Parsing/EscapedLiteral.cs
@@ -56,7 +56,7 @@ public static class EscapedLiteral
         var unicode = input.Length - startIndex >= 4
             ? input.Slice(startIndex, 4)
             : input.Slice(startIndex);
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         if (int.TryParse(unicode, NumberStyles.HexNumber, null, out var result))
 #else
             if (int.TryParse(unicode.ToString(), NumberStyles.HexNumber, null, out var result))
@@ -80,9 +80,12 @@ public static class EscapedLiteral
     {
         var max = input.Length;
         var resultIndex = 0;
-        for (var inputIndex = 0; inputIndex < max; inputIndex++)
+
+        var inputIndex = 0;
+        while (inputIndex < max)
         {
             int nextInputIndex;
+
             if (inputIndex + 1 < max)
             {
                 nextInputIndex = inputIndex + 1;
@@ -99,25 +102,25 @@ public static class EscapedLiteral
                 {
                     // GetUnicode will throw if code is illegal
                     resultBuffer[resultIndex++] = GetUnicode(input, nextInputIndex + 1);
-                    inputIndex += 5;  // move to last unicode character
-                    continue;
+                    inputIndex += 6;  // move to last unicode character
                 }
-
-                if (TryGetChar(input[nextInputIndex], out var realChar, includeFormatterOptionChars))
+                else if (TryGetChar(input[nextInputIndex], out var realChar, includeFormatterOptionChars))
                 {
                     resultBuffer[resultIndex++] = realChar;
+                    inputIndex += 2;
                 }
                 else
                 {
                     throw new ArgumentException($"Unrecognized escape sequence \"{input[inputIndex]}{input[nextInputIndex]}\" in literal.");
                 }
-                inputIndex++;
             }
             else
             {
                 resultBuffer[resultIndex++] = input[inputIndex];
+                inputIndex++;
             }
         }
+
         return resultBuffer.Slice(0, resultIndex);
     }
 

--- a/src/SmartFormat/Core/Parsing/ParsingErrors.cs
+++ b/src/SmartFormat/Core/Parsing/ParsingErrors.cs
@@ -1,6 +1,4 @@
-﻿// 
-// Copyright SmartFormat Project maintainers and contributors.
-// Licensed under the MIT license.
+﻿// Licensed under the MIT license.
 
 using System;
 using System.Collections.Generic;
@@ -99,6 +97,7 @@ public class ParsingErrors : Exception   //NOSONAR
     }
 
     ///<inheritdoc/>
+    [Obsolete("This API supports obsolete formatter-based serialization. It will be removed in version 4.")]
     protected ParsingErrors(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context)

--- a/src/SmartFormat/Core/Settings/PoolSettings.cs
+++ b/src/SmartFormat/Core/Settings/PoolSettings.cs
@@ -31,6 +31,6 @@ public struct PoolSettings
 #if DEBUG
         = true;
 #else
-            = false;
+        = false;
 #endif
 }

--- a/src/SmartFormat/Extensions/LocalizationFormattingException.cs
+++ b/src/SmartFormat/Extensions/LocalizationFormattingException.cs
@@ -35,8 +35,9 @@ public class LocalizationFormattingException : FormattingException
     }
 
     ///<inheritdoc/>
+    [Obsolete("This API supports obsolete formatter-based serialization. It will be removed in version 4.")]
     protected LocalizationFormattingException(
-        System.Runtime.Serialization.SerializationInfo info,
-        System.Runtime.Serialization.StreamingContext context) : base(info, context) 
-    { }
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) 
+        { }
 }

--- a/src/SmartFormat/Pooling/PoolingException.cs
+++ b/src/SmartFormat/Pooling/PoolingException.cs
@@ -23,6 +23,7 @@ public class PoolingException : InvalidOperationException
     }
 
     ///<inheritdoc/>
+    [Obsolete("This API supports obsolete formatter-based serialization. It will be removed in version 4.")]
     protected PoolingException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context)

--- a/src/SmartFormat/SmartFormat.csproj
+++ b/src/SmartFormat/SmartFormat.csproj
@@ -19,14 +19,14 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="ZString" Version="2.6.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netStandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netStandard2.0'">
         <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     </ItemGroup>


### PR DESCRIPTION
* Add `net8.0` as target framework
* Update target framework `net461` to `net462`
* Mark CTOR overload `(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)` as obsolete (like it is in net8.0).
* Update proprocessor directives for target frameworks and NuGet packages
* Change appveyor_build_worker_image to Ubuntu2204 (image has net8.0 installed)
