### PR TITLE
chore:: Remove redundant DependsOnTargets

### DIFF
--- a/src/SmartFormat/SmartFormat.csproj
+++ b/src/SmartFormat/SmartFormat.csproj
@@ -54,13 +54,4 @@ It uses extensions to provide named placeholders, localization, pluralization, g
         </AssemblyAttribute>
     </ItemGroup>
 
-    <!-- Added to include SmartFormat.ZString.dll into the nuget package -->
-    <!-- BuildOnlySettings will add XML-docs to *.nupkg, and PDBs to *.snupkg (if generated) -->
-    <!-- The order of DependsOnTargets arguments is important  -->
-    <Target DependsOnTargets="BuildOnlySettings;ResolveReferences" Name="CopyProjectReferencesToPackage">
-        <ItemGroup>
-            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-        </ItemGroup>
-    </Target>
-
 </Project>


### PR DESCRIPTION
Remove redundant DependsOnTargets to SmartFormat.ZString.dll (remnant after moving to v3.4.0)