### PR TITLE
refactor: Internal SmartFormat.Pooling classes

### DIFF
--- a/src/SmartFormat.Tests/Pooling/CollectionPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/CollectionPoolTests.cs
@@ -11,7 +11,6 @@ public class CollectionPoolTests
     {
         CollectionPool<List<int>, int>.Instance.Clear();
         var cp = CollectionPool<List<int>, int>.Instance;
-        cp.Pool.IsPoolingEnabled = true;
         return cp;
     }
 

--- a/src/SmartFormat.Tests/Pooling/ConcurrentPoolingTests.cs
+++ b/src/SmartFormat.Tests/Pooling/ConcurrentPoolingTests.cs
@@ -43,7 +43,7 @@ public class ConcurrentPoolingTests
         };
 
         var options = new ParallelOptions { MaxDegreeOfParallelism = 10 };
-        var pool = new ObjectPoolConcurrent<ObjectPoolClassesTests.SomePoolObject>(policy) { IsPoolingEnabled = true };
+        var pool = new ObjectPoolConcurrent<ObjectPoolClassesTests.SomePoolObject>(policy);
 
         Assert.That(() =>
             Parallel.For(0L, 1000, options, (i, loopState) =>

--- a/src/SmartFormat.Tests/Pooling/DictionaryPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/DictionaryPoolTests.cs
@@ -10,7 +10,6 @@ public class DictionaryPoolTests
     {
         DictionaryPool<int, string>.Instance.Clear();
         var dp = DictionaryPool<int, string>.Instance;
-        dp.Pool.IsPoolingEnabled = true;
         return dp;
     }
 

--- a/src/SmartFormat.Tests/Pooling/HashSetPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/HashSetPoolTests.cs
@@ -10,7 +10,6 @@ public class HashSetPoolTests
     {
         ListPool<int>.Instance.Clear();
         var hsp = HashSetPool<int>.Instance;
-        hsp.Pool.IsPoolingEnabled = true;
         return hsp;
     }
         

--- a/src/SmartFormat.Tests/Pooling/ListPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/ListPoolTests.cs
@@ -10,7 +10,6 @@ public class ListPoolTests
     {
         ListPool<string>.Instance.Clear();
         var lp = ListPool<string>.Instance;
-        lp.Pool.IsPoolingEnabled = true;
         return lp;
     }
         

--- a/src/SmartFormat.Tests/Pooling/ObjectPoolClassesTests.cs
+++ b/src/SmartFormat.Tests/Pooling/ObjectPoolClassesTests.cs
@@ -40,7 +40,6 @@ public class ObjectPoolClassesTests
             var constructedType = type.MakeGenericType(typeof(SomePoolObject));
             var instance = (ObjectPool<SomePoolObject>)Activator.CreateInstance(constructedType, policy)!;
                 
-            instance.IsPoolingEnabled = true;
             instance.Clear();
             yield return instance;
         }
@@ -255,8 +254,8 @@ public class ObjectPoolClassesTests
     public void Disabled_Pooling_Should_Only_Return_New_Instances(object poolAsObj)
     {
         var pool = (ObjectPool<SomePoolObject>) poolAsObj;
-        var savedPoolingEnabled = pool.IsPoolingEnabled;
-        pool.IsPoolingEnabled = false;
+        var savedPoolingEnabled = PoolSettings.IsPoolingEnabled;
+        PoolSettings.IsPoolingEnabled = false;
             
         var active = new List<SomePoolObject>();
         for (var i = 1; i <= 5; i++)
@@ -268,7 +267,7 @@ public class ObjectPoolClassesTests
         {
             pool.Return(a);
         }
-        pool.IsPoolingEnabled = savedPoolingEnabled;
+        PoolSettings.IsPoolingEnabled = savedPoolingEnabled;
 
         Assert.Multiple(() =>
         {

--- a/src/SmartFormat.Tests/Pooling/StringBuilderPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/StringBuilderPoolTests.cs
@@ -13,7 +13,6 @@ public class StringBuilderPoolTests
     {
         StringBuilderPool.Instance.Clear();
         var sbp = StringBuilderPool.Instance;
-        sbp.Pool.IsPoolingEnabled = true;
         return sbp;
     }
 

--- a/src/SmartFormat.Tests/Pooling/StringOutputPoolTests.cs
+++ b/src/SmartFormat.Tests/Pooling/StringOutputPoolTests.cs
@@ -11,7 +11,6 @@ public class StringOutputPoolTests
     {
         StringOutputPool.Instance.Clear();
         var sop = StringOutputPool.Instance;
-        sop.Pool.IsPoolingEnabled = true;
         return sop;
     }
         

--- a/src/SmartFormat/Pooling/ObjectPools/LinkedPool.cs
+++ b/src/SmartFormat/Pooling/ObjectPools/LinkedPool.cs
@@ -46,7 +46,7 @@ internal class LinkedPool<T> : ObjectPool<T> where T : class
     public override T Get()
     {
         // Always just create a new instance, if pooling is disabled
-        if (!IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
+        if (!PoolSettings.IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
 
         T item;
         if (PoolFirst == null)
@@ -74,7 +74,7 @@ internal class LinkedPool<T> : ObjectPool<T> where T : class
     public override void Return(T element)
     {
         // Never put an instance to the stack, if pooling is disabled
-        if (!IsPoolingEnabled) return;
+        if (!PoolSettings.IsPoolingEnabled) return;
 
         var listItem = PoolFirst;
         while (listItem != null)

--- a/src/SmartFormat/Pooling/ObjectPools/ObjectPool.cs
+++ b/src/SmartFormat/Pooling/ObjectPools/ObjectPool.cs
@@ -29,8 +29,9 @@ internal abstract class ObjectPool<T> : IObjectPool<T> where T : class
 
     /// <summary>
     /// Indicates whether object pooling is enabled (<see langword="true"/>).
-    /// <para>Default is taken from <see cref="PoolSettings.IsPoolingEnabled"/></para>
+    /// <para>Set or gets <see cref="PoolSettings.IsPoolingEnabled"/></para>
     /// </summary>
+    [Obsolete("Use PoolSettings.IsPoolingEnabled instead.")]
     public bool IsPoolingEnabled
     {
         get => PoolSettings.IsPoolingEnabled;

--- a/src/SmartFormat/Pooling/ObjectPools/ObjectPoolConcurrent.cs
+++ b/src/SmartFormat/Pooling/ObjectPools/ObjectPoolConcurrent.cs
@@ -41,7 +41,7 @@ internal class ObjectPoolConcurrent<T> : ObjectPool<T> where T : class
     public override T Get()
     {
         // Always just create a new instance, if pooling is disabled
-        if (!IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
+        if (!PoolSettings.IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
 
         if (!_stack.TryPop(out var element))
         {
@@ -58,7 +58,7 @@ internal class ObjectPoolConcurrent<T> : ObjectPool<T> where T : class
     public override void Return(T element)
     {
         // Never put an instance to the stack, if pooling is disabled
-        if (!IsPoolingEnabled) return;
+        if (!PoolSettings.IsPoolingEnabled) return;
             
         // This is a safe, but expensive check
         if (PoolSettings.CheckReturnedObjectsExistInPool && !_stack.IsEmpty && _stack.Contains(element))

--- a/src/SmartFormat/Pooling/ObjectPools/ObjectPoolSingleThread.cs
+++ b/src/SmartFormat/Pooling/ObjectPools/ObjectPoolSingleThread.cs
@@ -41,7 +41,7 @@ internal class ObjectPoolSingleThread<T> : ObjectPool<T> where T : class
     public override T Get()
     {
         // Always just create a new instance, if pooling is disabled
-        if (!IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
+        if (!PoolSettings.IsPoolingEnabled) return PoolPolicy.FunctionOnCreate();
 
         T element;
         if (_stack.Count == 0)
@@ -71,7 +71,7 @@ internal class ObjectPoolSingleThread<T> : ObjectPool<T> where T : class
     public override void Return(T element)
     {
         // Never put an instance to the stack, if pooling is disabled
-        if (!IsPoolingEnabled) return;
+        if (!PoolSettings.IsPoolingEnabled) return;
 
         // This is a safe, but expensive check
         if (PoolSettings.CheckReturnedObjectsExistInPool && _stack.Count > 0 && _stack.Contains(element))

--- a/src/SmartFormat/Pooling/PoolRegistry.cs
+++ b/src/SmartFormat/Pooling/PoolRegistry.cs
@@ -15,25 +15,25 @@ internal static class PoolRegistry
     public static readonly ConcurrentDictionary<Type, object> Items = new();
 
     /// <summary>
-    /// Adds a pool to the registry.
+    /// Gets the instance of the pool that already exists in the registry,
+    /// or adds new pool to the registry and returns it.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="pool"></param>
-    /// <returns>The instance of pool which was added.</returns>
-    public static T Add<T>(T pool) where T: class
+    /// <returns>The instance of the pool that already exists, or that was newly added.</returns>
+    public static T GetOrAdd<T>(T pool) where T: class
     {
-        Items.TryAdd(pool.GetType(), pool);
-        return pool;
+        return (T) Items.GetOrAdd(typeof(T), pool);
     }
 
     /// <summary>
-    /// Removes a pool from the registry.
+    /// Tries to remove the pool from the registry.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="pool"></param>
-    public static void Remove<T>(T pool) where T: class
+    public static void TryRemove<T>(T pool) where T: class
     {
-        Items.TryRemove(pool.GetType(), out _);
+        Items.TryRemove(typeof(T), out _);
     }
 
     /// <summary>

--- a/src/SmartFormat/Pooling/SmartPools/FormatDetailsPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/FormatDetailsPool.cs
@@ -41,8 +41,7 @@ internal sealed class FormatDetailsPool : SmartPoolAbstract<FormatDetails>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static FormatDetailsPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static FormatDetailsPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/FormatPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/FormatPool.cs
@@ -41,8 +41,7 @@ internal sealed class FormatPool : SmartPoolAbstract<Format>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static FormatPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static FormatPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/FormattingInfoPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/FormattingInfoPool.cs
@@ -41,8 +41,7 @@ internal sealed class FormattingInfoPool : SmartPoolAbstract<FormattingInfo>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static FormattingInfoPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static FormattingInfoPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/LiteralTextPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/LiteralTextPool.cs
@@ -40,8 +40,7 @@ internal sealed class LiteralTextPool : SmartPoolAbstract<LiteralText>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static LiteralTextPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static LiteralTextPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/ParsingErrorsPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/ParsingErrorsPool.cs
@@ -40,8 +40,7 @@ internal sealed class ParsingErrorsPool : SmartPoolAbstract<ParsingErrors>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static ParsingErrorsPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static ParsingErrorsPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/PlaceholderPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/PlaceholderPool.cs
@@ -40,8 +40,7 @@ internal sealed class PlaceholderPool : SmartPoolAbstract<Placeholder>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static PlaceholderPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static PlaceholderPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/SelectorPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/SelectorPool.cs
@@ -40,8 +40,7 @@ internal sealed class SelectorPool : SmartPoolAbstract<Selector>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static SelectorPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static SelectorPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/SplitListPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/SplitListPool.cs
@@ -42,8 +42,7 @@ internal sealed class SplitListPool : SmartPoolAbstract<SplitList>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static SplitListPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static SplitListPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SmartPools/StringOutputPool.cs
+++ b/src/SmartFormat/Pooling/SmartPools/StringOutputPool.cs
@@ -33,8 +33,7 @@ internal sealed class StringOutputPool : SmartPoolAbstract<StringOutput>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static StringOutputPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static StringOutputPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SpecializedPools/CollectionPool.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/CollectionPool.cs
@@ -35,7 +35,7 @@ internal class CollectionPool<TCollection, TItem> : SpecializedPoolAbstract<TCol
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static CollectionPool<TCollection, TItem> Instance => Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static CollectionPool<TCollection, TItem> Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SpecializedPools/DictionaryPool.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/DictionaryPool.cs
@@ -31,8 +31,7 @@ internal sealed class DictionaryPool<TKey, TValue> : CollectionPool<Dictionary<T
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static new DictionaryPool<TKey, TValue> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new DictionaryPool<TKey, TValue> Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SpecializedPools/HashSetPool.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/HashSetPool.cs
@@ -31,8 +31,7 @@ internal sealed class HashSetPool<T> : CollectionPool<HashSet<T>, T>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static new HashSetPool<T> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new HashSetPool<T> Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SpecializedPools/ListPool.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/ListPool.cs
@@ -31,8 +31,7 @@ internal sealed class ListPool<T> : CollectionPool<List<T>, T>
     }
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static new ListPool<T> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new ListPool<T> Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }

--- a/src/SmartFormat/Pooling/SpecializedPools/SpecializedPoolAbstract.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/SpecializedPoolAbstract.cs
@@ -47,7 +47,7 @@ internal abstract class SpecializedPoolAbstract<T> : IDisposable where T : class
     internal void Reset(bool? isThreadSafeMode)
     {
         _isThreadSafeMode = isThreadSafeMode ?? SmartSettings.IsThreadSafeMode;
-        PoolRegistry.Remove(this);
+        PoolRegistry.TryRemove(this);
         Pool.Dispose();
         Pool = LazyCreateObjectPool();
     }

--- a/src/SmartFormat/Pooling/SpecializedPools/StringBuilderPool.cs
+++ b/src/SmartFormat/Pooling/SpecializedPools/StringBuilderPool.cs
@@ -43,8 +43,7 @@ internal sealed class StringBuilderPool : SpecializedPoolAbstract<StringBuilder>
     public int DefaultStringBuilderCapacity { get; set; } = 1024;
 
     /// <summary>
-    /// Gets a singleton instance of the pool.
+    /// Gets the existing instance of the pool or lazy-creates a new one, which is then added to the registry.
     /// </summary>
-    public static StringBuilderPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static StringBuilderPool Instance => PoolRegistry.GetOrAdd(Lazy.Value);
 }


### PR DESCRIPTION
* Mark instance property `ObjectPool.IsPoolingEnabled` as obsolete in favor of `SmartSettings.IsPoolingEnabled`
* Simplify pooling classes, especially when creating new pools
* Make methods and their names more consistent