### PR TITLE
Add Dutch to CommonLanguagesTimeTextInfo

### DIFF
--- a/src/SmartFormat.Extensions.Time/Utilities/CommonLanguagesTimeTextInfo.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/CommonLanguagesTimeTextInfo.cs
@@ -159,7 +159,7 @@ public static class CommonLanguagesTimeTextInfo
         Ptxt_s = ["{0}s"],
         Ptxt_ms = ["{0}ms"],
         Ptxt_lessThan = "minder dan {0}"
-    }
+    };
     
     /// <summary>
     /// Adds a <see cref="TimeTextInfo"/> for a language.

--- a/src/SmartFormat.Extensions.Time/Utilities/CommonLanguagesTimeTextInfo.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/CommonLanguagesTimeTextInfo.cs
@@ -141,6 +141,27 @@ public static class CommonLanguagesTimeTextInfo
     };
 
     /// <summary>
+    /// Gets the <see cref="TimeTextInfo"/> for the Dutch language.
+    /// </summary>
+    public static TimeTextInfo Dutch => new()
+    {
+        PluralRule = PluralRules.GetPluralRule("nl"),
+        Ptxt_week = ["{0} week", "{0} weken"],
+        Ptxt_day = ["{0} dag", "{0} dagen"],
+        Ptxt_hour = ["{0} uur", "{0} uur"],
+        Ptxt_minute = ["{0} minuut", "{0} minuten"],
+        Ptxt_second = ["{0} seconde", "{0} seconden"],
+        Ptxt_millisecond = ["{0} milliseconde", "{0} milliseconden"],
+        Ptxt_w = ["{0}w"],
+        Ptxt_d = ["{0}d"],
+        Ptxt_h = ["{0}u"],
+        Ptxt_m = ["{0}m"],
+        Ptxt_s = ["{0}s"],
+        Ptxt_ms = ["{0}ms"],
+        Ptxt_lessThan = "minder dan {0}"
+    }
+    
+    /// <summary>
     /// Adds a <see cref="TimeTextInfo"/> for a language.
     /// </summary>
     /// <param name="twoLetterIsoLanguageName">The string to get the associated <see cref="System.Globalization.CultureInfo"/></param>
@@ -177,6 +198,7 @@ public static class CommonLanguagesTimeTextInfo
             "pt" => Portuguese,
             "it" => Italian,
             "de" => German,
+            "nl" => Dutch,
             _ => null
         };
     }

--- a/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
@@ -80,9 +80,9 @@ public class TimeFormatterTests
         timeFormatter.FallbackLanguage = useFallbackLanguage ? "en" : string.Empty;
 
         if(useFallbackLanguage)
-            Assert.That(() => smart.Format("{0:time(nl):noless}", new TimeSpan(1,2,3)), Throws.Nothing);
+            Assert.That(() => smart.Format("{0:time(ie):noless}", new TimeSpan(1,2,3)), Throws.Nothing);
         else
-            Assert.That(() => smart.Format("{0:time(nl):noless}", new TimeSpan(1,2,3)), Throws.TypeOf<FormattingException>().And.Message.Contains(nameof(TimeTextInfo)));
+            Assert.That(() => smart.Format("{0:time(ie):noless}", new TimeSpan(1,2,3)), Throws.TypeOf<FormattingException>().And.Message.Contains(nameof(TimeTextInfo)));
     }
 
 


### PR DESCRIPTION
This adds Dutch as one of the defaults for the `TimeSpan` formatter extension.

Currently, this change has no unit tests associated with it as most languages in this file don't have unit tests (only some for English, German and French). Let me know if I should add unit tests anyway!