### PR TITLE
feat: Format.HasNested checks for existing Placeholder in Items

### DIFF
--- a/src/SmartFormat.Tests/Core/ParserTests.cs
+++ b/src/SmartFormat.Tests/Core/ParserTests.cs
@@ -888,4 +888,11 @@ public class ParserTests
         var exception = ser.ReadObject(stream) as ParsingErrors;
         Assert.That(exception, Is.TypeOf<ParsingErrors>());
     }
+
+    [Test]
+    public void Initialize_Format()
+    {
+        Assert.That(() => { _ = new Format().Initialize(new SmartSettings(), string.Empty, 0, 0, false); },
+            Throws.Nothing, "Overload is marked as obsolete");
+    }
 }

--- a/src/SmartFormat/Core/Parsing/Format.cs
+++ b/src/SmartFormat/Core/Parsing/Format.cs
@@ -83,14 +83,12 @@ public sealed class Format : FormatItem, IDisposable
     /// <param name="baseString">The base format string-</param>
     /// <param name="startIndex">The start index within the format base string.</param>
     /// <param name="endIndex">The end index within the format base string.</param>
-    /// <param name="hasNested"><see langword="true"/> if the nested formats exist.</param>
+    /// <param name="hasNested"><see langword="true"/> if the format at least one nested <see cref="Placeholder"/>.</param>
     /// <returns>This <see cref="Format"/> instance.</returns>
+    [Obsolete("Use the overload without 'hasNested' instead.")]
     public Format Initialize(SmartSettings smartSettings, string baseString, int startIndex, int endIndex, bool hasNested)
     {
-        base.Initialize(smartSettings, null, baseString, startIndex, endIndex);
-        ParentPlaceholder = null;
-        HasNested = hasNested;
-
+        Initialize(smartSettings, baseString, startIndex, endIndex);
         return this;
     }
 
@@ -104,7 +102,6 @@ public sealed class Format : FormatItem, IDisposable
         Clear();
 
         ParentPlaceholder = null;
-        HasNested = false;
 
 #pragma warning disable S3267 // Don't use LINQ in favor of less GC
         // Return and clear FormatItems we own
@@ -143,11 +140,11 @@ public sealed class Format : FormatItem, IDisposable
     /// Gets the <see cref="List{T}"/> of <see cref="FormatItem"/>s.
     /// </summary>
     public List<FormatItem> Items { get; } = new();
-        
+
     /// <summary>
-    /// Returns <see langword="true"/>, if the <see cref="Format"/> is nested.
+    /// Returns <see langword="true"/>, if the <see cref="Items"/> contain at least one nested <see cref="Placeholder"/>.
     /// </summary>
-    public bool HasNested { get; internal set; }
+    public bool HasNested => Items.Exists(i => i is Placeholder);
 
     #endregion
 
@@ -199,7 +196,6 @@ public sealed class Format : FormatItem, IDisposable
             else
             {
                 // item is a placeholder -- we can't split a placeholder though.
-                substring.HasNested = true;
             }
 
             substring.Items.Add(newItem);

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -398,7 +398,6 @@ public class Parser
         nestedDepth++;
         newPlaceholder = PlaceholderPool.Instance.Get().Initialize(_resultFormat, _index.Current, nestedDepth);
         _resultFormat.Items.Add(newPlaceholder);
-        _resultFormat.HasNested = true;
         _index.Operator = _index.SafeAdd(_index.Current, 1);
         _index.Selector = 0;
         _index.NamedFormatterStart = PositionUndefined;

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -191,7 +191,7 @@ public class ListFormatter : IFormatter, ISource, IInitializer
             // The format is not nested,
             // so we will treat it as an ItemFormat:
             var newItemFormat = FormatPool.Instance.Get().Initialize(_smartSettings, itemFormat.BaseString,
-                itemFormat.StartIndex, itemFormat.EndIndex, true);
+                itemFormat.StartIndex, itemFormat.EndIndex);
             itemFormat.ParentPlaceholder = formattingInfo.Placeholder;
 
             var newPlaceholder = PlaceholderPool.Instance.Get().Initialize(newItemFormat, itemFormat.StartIndex, 0);


### PR DESCRIPTION
Closes  #415
* `Format.HasNested` checks Items for existing `Placeholder`
* Update Format Class Initialization (mark overload with arg `bool hasNested` as obsolete