### PR TITLE
feature: ReflectionSource and DictionarySource

### DIFF
--- a/src/SmartFormat.Tests/Extensions/DictionarySourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/DictionarySourceTests.cs
@@ -51,7 +51,7 @@ public class DictionarySourceTests
         d.Object = new { Prop1 = "a", Prop2 = "b", Prop3 = "c", };
 
         return new object[] {
-            d,
+            d
         };
     }
 

--- a/src/SmartFormat.Tests/Extensions/DictionarySourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/DictionarySourceTests.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
 using SmartFormat.Tests.TestUtils;
-using SmartFormat.Utilities;
 
 namespace SmartFormat.Tests.Extensions;
 
@@ -76,17 +75,17 @@ public class DictionarySourceTests
     }
 
     [Test]
-    public void Test_Dynamic()
+    public void Test_Dynamic_CaseSensitive()
     {
-        var formatter = Smart.CreateDefaultSmartFormat();
+        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings {CaseSensitivity = CaseSensitivityType.CaseSensitive});
         formatter.AddExtensions(new DictionarySource());
 
-        var formats = new[]
+        var formats = new string[]
         {
             "Chained: {0.Numbers.One} {Numbers.Two} {Letters.A} {Object.Prop1} {Raw.X}",
             "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}} {Raw:{X}}"
         };
-        var expected = new[]
+        var expected = new string[]
         {
             "Chained: 1 2 a a z",
             "Nested: 1 2 a a z"
@@ -98,20 +97,20 @@ public class DictionarySourceTests
     [Test]
     public void Test_Dynamic_CaseInsensitive()
     {
-        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings {CaseSensitivity = CaseSensitivityType.CaseInsensitive});
+        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings { CaseSensitivity = CaseSensitivityType.CaseInsensitive});
         formatter.AddExtensions(new DictionarySource());
 
         var formats = new string[]
         {
-            "Chained: {0.Numbers.One} {Numbers.Two} {Letters.A} {Object.Prop1} {Raw.x}",
-            "Nested: {0:{Numbers:{One} {Two}}} {Letters:{A}} {Object:{Prop1}} {Raw:{x}}"
+            "Chained: {0.Numbers.ONE} {Numbers.TWO} {Letters.A} {Object.PROP1} {Raw.x}",
+            "Nested: {0:{Numbers:{ONE} {TWO}}} {Letters:{A}} {Object:{PROP1}} {Raw:{x}}"
         };
         var expected = new string[]
         {
             "Chained: 1 2 a a z",
             "Nested: 1 2 a a z"
         };
-        var args = (object[])GetDynamicArgs();
+        var args = (object[]) GetDynamicArgs();
         formatter.Test(formats, args, expected);
     }
 

--- a/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
@@ -268,7 +268,9 @@ public class ReflectionSourceTests
         Assert.Multiple(() =>
         {
             Assert.That(ReflectionSource.TypeCache, Has.Count.EqualTo(ReflectionSource.MaxCacheSize));
+#if !NET6_0_OR_GREATER
             Assert.That(ReflectionSource.KeyList, Has.Count.EqualTo(ReflectionSource.TypeCache.Count));
+    #endif
             // Item2 of the value tuple is the name of the field or method
             Assert.That(ReflectionSource.TypeCache.First().Key.Item2, Is.EqualTo("SomeValue"), "Last added item is kept in cache");
         });

--- a/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
@@ -79,6 +78,19 @@ public class ReflectionSourceTests
         var args = GetArgs();
         var actual = formatter.Format(format, args);
         Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Members_CaseInsensitive_With_Same_OrdinalIgnoreCase_Name()
+    {
+        var formatter = GetFormatter(new SmartSettings
+            { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
+        
+        // The first property matches the case-insensitive name
+        var args = new { Data = new { Value = 123, VALUE = "456" } };
+
+        var actual = formatter.Format("{Data.Value} and {Data.VALUE} with type {Data.VALUE.GetType}", args);
+        Assert.That(actual, Is.EqualTo("123 and 123 with type System.Int32"));
     }
 
     /// <summary>

--- a/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ReflectionSourceTests.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
@@ -10,6 +15,14 @@ namespace SmartFormat.Tests.Extensions;
 [TestFixture]
 public class ReflectionSourceTests
 {
+    private static SmartFormatter GetFormatter(SmartSettings? settings = null)
+    {
+        var smart = new SmartFormatter(settings ?? new SmartSettings())
+            .AddExtensions(new DefaultSource(), new ReflectionSource())
+            .AddExtensions(new DefaultFormatter());
+        return smart;
+    }
+
     private static object[] GetArgs()
     {
         return new object[] {
@@ -34,54 +47,42 @@ public class ReflectionSourceTests
     }
 #endif
 
-    [Test]
-    public void Test_Properties()
+    [TestCase("{0} {0.Length} {Length}", "Zero 4 4")]
+    [TestCase("{2.Year} {2.Month:00}-{2.Day:00}", "2222 02-02")]
+    [TestCase("{3.Value} {3.Anon}", "3 True")]
+    [TestCase("Chained: {4.FirstName} {4.FirstName.Length} {4.Address.City} {4.Address.State}", "Chained: Michael 7 Scranton Pennsylvania")]
+    [TestCase("Nested: {4:{FirstName:{} {Length} }{Address:{City} {State}}}", "Nested: Michael 7 Scranton Pennsylvania")]
+    public void Test_Properties_CaseSensitive(string format, string expected)
     {
+        var formatter = GetFormatter(new SmartSettings
+            { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
         // Length property for a string comes from StringSource
-        var formats = new[] {
-            "{0} {0.Length} {Length}",
-            "{2.Year} {2.Month:00}-{2.Day:00}",
-            "{3.Value} {3.Anon}",
-            "Chained: {4.FirstName} {4.FirstName.Length} {4.Address.City} {4.Address.State}",
-            "Nested: {4:{FirstName:{} {Length} }{Address:{City} {State}}}"
-        };
-        var expected = new[] {
-            "Zero 4 4",
-            "2222 02-02",
-            "3 True",
-            "Chained: Michael 7 Scranton Pennsylvania",
-            "Nested: Michael 7 Scranton Pennsylvania"
-        };
+        formatter.AddExtensions(new StringSource());
+
         var args = GetArgs();
-        var smart = Smart.CreateDefaultSmartFormat();
-        smart.Test(formats, args, expected);
+        var actual = formatter.Format(format, args);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
-    [Test]
-    public void Test_Properties_CaseInsensitive()
+    [TestCase("{0} {0.lenGth} {length}", "Zero 4 4")]
+    [TestCase("{2.YEar} {2.MoNth:00}-{2.daY:00}", "2222 02-02")]
+    [TestCase("{3.Value} {3.AnoN}", "3 True")]
+    [TestCase("Chained: {4.fIrstName} {4.Firstname.Length} {4.Address.City} {4.aDdress.StAte}", "Chained: Michael 7 Scranton Pennsylvania")]
+    [TestCase("Nested: {4:{FirstName:{} {Length} }{Address:{City} {StaTe}}}", "Nested: Michael 7 Scranton Pennsylvania")]
+    public void Test_Properties_CaseInsensitive(string format, string expected)
     {
-        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings
+        var formatter = GetFormatter(new SmartSettings
             {CaseSensitivity = CaseSensitivityType.CaseInsensitive});
-            
         // Length property for a string comes from StringSource
-        var formats = new []
-        {
-            "{0} {0.lenGth} {length}", "{2.YEar} {2.MoNth:00}-{2.daY:00}", "{3.Value} {3.AnoN}",
-            "Chained: {4.fIrstName} {4.Firstname.Length} {4.Address.City} {4.aDdress.StAte}",
-            "Nested: {4:{FirstName:{} {Length} }{Address:{City} {StaTe}}}",
-            // Due to double-brace escaping, the spacing in this nested format is irregular
-        };
-        var expected = new []
-        {
-            "Zero 4 4", "2222 02-02", "3 True", "Chained: Michael 7 Scranton Pennsylvania",
-            "Nested: Michael 7 Scranton Pennsylvania",
-        };
+        formatter.AddExtensions(new StringSource());
+
         var args = GetArgs();
-        formatter.Test(formats, args, expected);
+        var actual = formatter.Format(format, args);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     /// <summary>
-    /// system.string methods are processed by <see cref="StringSource"/> since v3.0
+    /// System.String methods are processed by <see cref="StringSource"/> since v3.0
     /// </summary>
     [Test]
     public void Test_Parameterless_Methods()
@@ -89,23 +90,19 @@ public class ReflectionSourceTests
         var format = "{0} {0.ToLower} {ToLower} {ToUpper}";
         //var expected = "Zero zero zero ZERO";
 
-        var smart = new SmartFormatter()
-            .AddExtensions(new ReflectionSource(), new DefaultSource())
-            .AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter();
 
         var args = GetArgs();
         Assert.That(() => smart.Format(format, args), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("ToLower"));
     }
 
     /// <summary>
-    /// system.string methods are processed by <see cref="StringSource"/> since v3.0
+    /// System.String methods are processed by <see cref="StringSource"/> since v3.0
     /// </summary>
     [Test]
     public void Test_Methods_CaseInsensitive()
     {
-        var smart = new SmartFormatter(new SmartSettings { CaseSensitivity = CaseSensitivityType.CaseInsensitive })
-            .AddExtensions(new ReflectionSource())
-            .AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter(new SmartSettings { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
 
         var format = "{0} {0.ToLower} {toloWer} {touPPer}";
         //var expected = "Zero zero zero ZERO";
@@ -116,27 +113,21 @@ public class ReflectionSourceTests
     [Test]
     public void Void_Methods_Should_Just_Be_Ignored()
     {
-        var smart = new SmartFormatter()
-            .AddExtensions(new ReflectionSource(), new DefaultSource())
-            .AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter();
         Assert.That(() => smart.Format("{0.Clear}", smart.SourceExtensions), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("Clear"));
     }
 
     [Test]
     public void Methods_With_Parameter_Should_Just_Be_Ignored()
     {
-        var smart = new SmartFormatter()
-            .AddExtensions(new ReflectionSource(), new DefaultSource())
-            .AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter();
         Assert.That(() => smart.Format("{0.Add}", smart.SourceExtensions), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("Add"));
     }
 
     [Test]
     public void Properties_With_No_Getter_Should_Just_Be_Ignored()
     {
-        var smart = new SmartFormatter()
-            .AddExtensions(new ReflectionSource(), new DefaultSource())
-            .AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter();
         Assert.That(() => smart.Format("{Misc.OnlySetterProperty}", new { Misc = new MiscObject() }), Throws.Exception.TypeOf(typeof(FormattingException)).And.Message.Contains("OnlySetterProperty"));
     }
         
@@ -153,14 +144,14 @@ public class ReflectionSourceTests
         var args = new object[] {
             new MiscObject(),
         };
-        var smart = Smart.CreateDefaultSmartFormat();
+        var smart = GetFormatter();
         smart.Test(formats, args, expected);
     }
 
     [Test]
     public void Test_Fields_CaseInsensitive()
     {
-        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings{ CaseSensitivity = CaseSensitivityType.CaseInsensitive });
+        var formatter = GetFormatter(new SmartSettings{ CaseSensitivity = CaseSensitivityType.CaseInsensitive });
             
         var formats = new string[] { "{field}" };
         var expected = new string[] { "Field" };
@@ -172,7 +163,7 @@ public class ReflectionSourceTests
     public void Test_Get_Property_From_Base_Class()
     {
         var derived = new DerivedMiscObject();
-        var formatter = Smart.CreateDefaultSmartFormat(new SmartSettings{ CaseSensitivity = CaseSensitivityType.CaseInsensitive });
+        var formatter = GetFormatter(new SmartSettings{ CaseSensitivity = CaseSensitivityType.CaseInsensitive });
 
         Assert.Multiple(() =>
         {
@@ -186,10 +177,9 @@ public class ReflectionSourceTests
     {
         // Note: Cached Property values work the same as cached methods
 
-        var formatter = Smart.CreateDefaultSmartFormat();
-        var reflectionSource = formatter.GetSourceExtension<ReflectionSource>()!;
+        var formatter = GetFormatter();
             
-        var typeCache = reflectionSource.TypeCache;
+        var typeCache = ReflectionSource.TypeCache;
         var obj = new {Obj = new MiscObject { MethodReturnValue = "The Method Value"}};
         (System.Reflection.FieldInfo? field, System.Reflection.MethodInfo? method) found = default;
         Assert.Multiple(() =>
@@ -214,9 +204,8 @@ public class ReflectionSourceTests
     [Test]
     public void Test_With_TypeCaching_And_Property_Value()
     {
-        var formatter = Smart.CreateDefaultSmartFormat();
-        var reflectionSource = formatter.GetSourceExtension<ReflectionSource>()!;
-        var typeCache = reflectionSource.TypeCache;
+        var formatter = GetFormatter();
+        var typeCache = ReflectionSource.TypeCache;
         var obj = new {Obj = new MiscObject { Field = "The Field Value"}};
         (System.Reflection.FieldInfo? field, System.Reflection.MethodInfo? method) found = default;
 
@@ -225,7 +214,7 @@ public class ReflectionSourceTests
 
             // Invoke formatter 1st time
             Assert.That(formatter.Format("{Obj.Field}", obj), Is.EqualTo(obj.Obj.Field));
-            Assert.That(typeCache!.TryGetValue((typeof(MiscObject), nameof(MiscObject.Field)), out found), Is.True);
+            Assert.That(typeCache.TryGetValue((typeof(MiscObject), nameof(MiscObject.Field)), out found), Is.True);
             Assert.That(found.field?.GetValue(obj.Obj), Is.EqualTo(obj.Obj.Field));
         });
 
@@ -242,31 +231,89 @@ public class ReflectionSourceTests
     [Test]
     public void Test_With_TypeCaching_Disabled()
     {
-        var formatter = Smart.CreateDefaultSmartFormat();
+        var formatter = GetFormatter();
         var reflectionSource = formatter.GetSourceExtension<ReflectionSource>()!;
+        ReflectionSource.TypeCache.Clear();
         reflectionSource.IsTypeCacheEnabled = false;
-        var typeCache = reflectionSource.TypeCache;
         var obj = new {Obj = new MiscObject { Field = "The Field Value", MethodReturnValue = "The Method Value"}};
         Assert.Multiple(() =>
         {
-
             // Invoke formatter, expecting results, but empty cache
             Assert.That(formatter.Format("{Obj.Field}", obj), Is.EqualTo(obj.Obj.Field));
             Assert.That(formatter.Format("{Obj.Method}", obj), Is.EqualTo(obj.Obj.MethodReturnValue));
-            Assert.That(typeCache!, Is.Empty);
+            Assert.That(ReflectionSource.TypeCache, Is.Empty);
         });
     }
 
     [Test]
     public void Nullable_Property_Should_Return_Empty_String()
     {
-        var smart = new SmartFormatter();
-        smart.AddExtensions(new DefaultSource(), new ReflectionSource());
-        smart.AddExtensions(new DefaultFormatter());
+        var smart = GetFormatter();
         var data = new {Person = new Person()};
 
         var result = smart.Format("{Person.Address?.City}", data);
         Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void Keep_Cache_Within_Limit_Of_MaxCacheSize()
+    {
+        var formatter = GetFormatter();
+        ReflectionSource.MaxCacheSize = 1;
+
+        // These args would create 2 items in the cache, which is more than the limit
+        var args = new { Data = new { SomeValue = 123 } };
+        _ = formatter.Format("{Data.SomeValue}", args);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ReflectionSource.TypeCache, Has.Count.EqualTo(ReflectionSource.MaxCacheSize));
+            Assert.That(ReflectionSource.KeyList, Has.Count.EqualTo(ReflectionSource.TypeCache.Count));
+            // Item2 of the value tuple is the name of the field or method
+            Assert.That(ReflectionSource.TypeCache.First().Key.Item2, Is.EqualTo("SomeValue"), "Last added item is kept in cache");
+        });
+
+        // Reset to default
+        ReflectionSource.MaxCacheSize = ReflectionSource.DefaultCacheSize;
+    }
+
+    [Test]
+    public void Parallel_Smart_Format()
+    {
+        // Switch to thread safety - otherwise the test would throw
+        var savedMode = ThreadSafeMode.SwitchOn();
+            
+        var results = new ConcurrentDictionary<long, string>();
+        var threadIds = new ConcurrentDictionary<int, int>();
+        var options = new ParallelOptions { MaxDegreeOfParallelism = 100 };
+        ReflectionSource.TypeCache.Clear();
+
+        Assert.That(code: () =>
+            Parallel.For(0L, 1000, options, (i, loopState) =>
+            {
+                var smart = new SmartFormatter()
+                    .AddExtensions(new DefaultSource(), new ReflectionSource())
+                    .AddExtensions(new DefaultFormatter());
+
+                var args = new { Data = new { Value = i} };
+
+                // register unique thread ids
+                threadIds.TryAdd(Environment.CurrentManagedThreadId, Environment.CurrentManagedThreadId);
+                results.TryAdd(i, smart.Format("{Data.Value}", args));
+            }), Throws.Nothing);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ReflectionSource.TypeCache,
+                Is.InstanceOf<ConcurrentDictionary<(Type, string?), (FieldInfo? field, MethodInfo? method)>>());
+            // Both 'Data' and 'Value' are cached
+            Assert.That(ReflectionSource.TypeCache, Has.Count.EqualTo(2));
+            Assert.That(results.All(kv => kv.Key.ToString() == kv.Value), Is.True);
+            Assert.That(threadIds, Has.Count.AtLeast(2)); // otherwise the test is not significant
+        });
+
+        // Restore to saved value
+        ThreadSafeMode.SwitchTo(savedMode);
     }
 
     public class MiscObject
@@ -309,10 +356,5 @@ public class ReflectionSourceTests
         public string FirstName = "first";
         public string LastName = "last";
         public Address? Address = null;
-    }
-
-    internal class TestReflectionSource : ReflectionSource
-    {
-        public static string TypeCacheFieldName => nameof(TypeCache);
     }
 }

--- a/src/SmartFormat/Extensions/DictionarySource.cs
+++ b/src/SmartFormat/Extensions/DictionarySource.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using SmartFormat.Core.Extensions;
@@ -17,8 +16,9 @@ namespace SmartFormat.Extensions;
 /// and <see cref="IReadOnlyDictionary{TKey,TValue}"/>.
 /// Include this source, if any of these types shall be used.
 /// <para/>
-/// For support of <see cref="IReadOnlyDictionary{TKey,TValue}"/> <see cref="IsIReadOnlyDictionarySupported"/> must be set to <see langword="true"/>.
-/// This uses Reflection and is slower than the other types despite caching. The cache scope is limited to this instance of <see cref="DictionarySource"/>.
+/// For support of <see cref="IReadOnlyDictionary{TKey,TValue}"/>, <see cref="IsIReadOnlyDictionarySupported"/> must be set to <see langword="true"/>.
+/// This uses Reflection and is slower than the other types despite caching.
+/// The cache scope is limited to this instance of <see cref="DictionarySource"/>.
 /// </summary>
 public class DictionarySource : Source
 {
@@ -31,36 +31,25 @@ public class DictionarySource : Source
         if (current is null) return false;
 
         var selector = selectorInfo.SelectorText;
+        var comparison = selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison();
 
-        // See if current is an IDictionary (including generic dictionaries) and contains the selector:
-        if (current is IDictionary rawDict)
-            foreach (DictionaryEntry entry in rawDict)
-            {
-                var key = entry.Key as string ?? entry.Key.ToString()!;
+        // Try to get the selector value for IDictionary
+        if (TryGetIDictionaryValue(current, selector, comparison, out var value))
+        {
+            selectorInfo.Result = value;
+            return true;
+        }
 
-                if (!key.Equals(selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()))
-                    continue;
+        // Try to get the selector value for Dictionary<,> and dynamics (ExpandoObject)
+        if (TryGetGenericDictionaryValue(current, selector, comparison, out value))
+        {
+            selectorInfo.Result = value;
+            return true;
+        }
 
-                selectorInfo.Result = entry.Value;
-                return true;
-            }
-
-        // This check is for dynamics (ExpandoObject):
-        if (current is IDictionary<string, object?> dict)
-            foreach (var entry in dict)
-            {
-                var key = entry.Key;
-
-                if (!key.Equals(selector, selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison()))
-                    continue;
-
-                selectorInfo.Result = entry.Value;
-                return true;
-            }
-
-        // This is for IReadOnlyDictionary<,> using Reflection
-        if (IsIReadOnlyDictionarySupported && TryGetDictionaryValue(current, selector,
-                selectorInfo.FormatDetails.Settings.GetCaseSensitivityComparison(), out var value))
+        // Try to get the selector value for IReadOnlyDictionary<,>
+        if (IsIReadOnlyDictionarySupported && TryGetReadOnlyDictionaryValue(current, selector,
+                comparison, out value))
         {
             selectorInfo.Result = value;
             return true;
@@ -69,16 +58,56 @@ public class DictionarySource : Source
         return false;
     }
 
+    /// <summary>
+    /// See if <paramref name="current"/> is an IDictionary (including generic dictionaries) that contains the selector.
+    /// </summary>
+    private static bool TryGetIDictionaryValue(object current, string selectorText, StringComparison comparison, out object? value)
+    {
+        if (current is IDictionary rawDict)
+            foreach (DictionaryEntry entry in rawDict)
+            {
+                var key = entry.Key as string ?? entry.Key.ToString()!;
+
+                if (!key.Equals(selectorText, comparison))
+                    continue;
+
+                value = entry.Value;
+                return true;
+            }
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Try to get the selector value for <see cref="Dictionary{TKey,TValue}"/> and dynamics (<see cref="System.Dynamic.ExpandoObject"/>).
+    /// </summary>
+    private static bool TryGetGenericDictionaryValue(object current, string selectorText, StringComparison comparison,
+        out object? value)
+    {
+        if (current is IDictionary<string, object?> dict)
+            foreach (var entry in dict)
+            {
+                var key = entry.Key;
+
+                if (!key.Equals(selectorText, comparison))
+                    continue;
+
+                value = entry.Value;
+                return true;
+            }
+
+        value = null;
+        return false;
+    }
+    
     #region *** IReadOnlyDictionary<,> ***
 
     /// <summary>
     /// Gets the instance type cache <see cref="IDictionary{TKey,TValue}"/> for <see cref="IReadOnlyDictionary{TKey,TValue}"/>.
     /// It could e.g. be pre-filled or cleared in a derived class.
+    /// The cache scope is limited to this instance of <see cref="DictionarySource"/>.
     /// </summary>
-    /// <remarks>
-    /// Note: For reading, <see cref="Dictionary{TKey, TValue}"/> and <see cref="ConcurrentDictionary{TKey,TValue}"/> perform equally.
-    /// For writing, <see cref="ConcurrentDictionary{TKey, TValue}"/> is slower with more garbage (tested under net5.0).
-    /// </remarks>
     protected internal readonly IDictionary<Type, (PropertyInfo, PropertyInfo)?> RoDictionaryTypeCache =
         new Dictionary<Type, (PropertyInfo, PropertyInfo)?>();
 
@@ -89,7 +118,7 @@ public class DictionarySource : Source
     /// </summary>
     public bool IsIReadOnlyDictionarySupported { get; set; } = false;
     
-    private bool TryGetDictionaryValue(object obj, string key, StringComparison comparison, out object? value)
+    private bool TryGetReadOnlyDictionaryValue(object obj, string key, StringComparison comparison, out object? value)
     {
         value = null;
 

--- a/src/SmartFormat/Extensions/ReflectionSource.cs
+++ b/src/SmartFormat/Extensions/ReflectionSource.cs
@@ -173,7 +173,7 @@ public class ReflectionSource : Source
 
         TypeCache[(sourceType, selector)] = (field, method);
 #else
-            while (TypeCache.Count > 0 && TypeCache.Count >= MaxCacheSize)
+        while (TypeCache.Count > 0 && TypeCache.Count >= MaxCacheSize)
         {
             // For frameworks NETCore3.1, we have to track insertion order by ourselves
             if (KeyList.TryDequeue(out var key))


### PR DESCRIPTION
Closes #425

### Changes to `ReflectionSource`

* Modified `ReflectionSource.TypeCache` to be static, shared across all instances.
* Implemented a control mechanism for the size of `ReflectionSource.TypeCache`. When the cache exceeds the maximum size limit, it now removes the oldest entry first, adhering to a First-In-First-Out (FIFO) strategy.
* Enhanced documentation for `CaseSensitivityType.CaseInsensitive`: Clarified that in scenarios where multiple members share the same name but differ in case, the first encountered member will be selected.

### Updates to `DictionarySource`

* Correction: Ensured that generic dictionaries and dynamic objects respect the case sensitivity settings.
* Added to the documentation: Specified that the cache for `IReadOnlyDictionary` is deliberately scoped to the instance level.