### PR TITLE
Implement ISpanFormattable for DefaultFormatter

### DIFF
--- a/.github/workflows/CheckWikiUpdates.yml
+++ b/.github/workflows/CheckWikiUpdates.yml
@@ -1,0 +1,59 @@
+name: Check for Wiki Updates
+
+on:
+  workflow_dispatch: # Allows manual trigger
+  # push: # Uncomment to run on push
+  schedule:
+    - cron: '0 0 * * *' # Runs once a day
+
+jobs:
+  check-wiki:
+    if: ${{ github.repository == 'axuno/SmartFormat' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki  # Checkout wiki to wiki folder
+
+      - name: Get last commit date, message and number of commits
+        id: get-info
+        run: |
+            cd wiki
+            DATE=$(git log -1 --format=%cd --date=iso)
+            FORMATTED_DATE=$(date -d"$DATE" +'%Y-%m-%d %H:%M:%S')
+            echo "updatedOn=$FORMATTED_DATE" >> $GITHUB_ENV
+            # The :a;N;$!ba; part buffers the input to ensure that all newline characters are replaced, not just those at the end of each line read
+            printf "commitMessage=\"%s\"\n" "$(git log -1 --pretty=%B | sed ':a;N;$!ba;s/\n/ ↲ /g' | sed "s/'/\\\\'/g")" >> $GITHUB_ENV
+            echo "hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
+            echo "commitCount=$(git rev-list --count --since='24 hours ago' HEAD)" >> $GITHUB_ENV
+      - name: Print variables
+        run: |
+          echo ${{ env.updatedOn }}
+          echo "${{ env.commitMessage }}"
+          echo ${{ env.hash }}
+          echo ${{ env.commitCount }}
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          path: main-repo # Checkout main repo to main-repo folder
+          token: ${{ secrets.WIKI_CHECK_TOKEN }}
+          ref: ${{ github.ref }}
+      - name: Create issue if wiki was updated
+        id: create-issue
+        if: ${{ env.commitCount != '0' }}
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.WIKI_CHECK_TOKEN }}
+          UpdatedOn: ${{ env.updatedOn }}
+          CommitMessage: ${{ env.commitMessage }}
+          CommitCount: ${{ env.commitCount }}
+          Hash: ${{ env.hash }}
+        with:
+          filename: main-repo/.github/workflows/Wiki_Update_Issue_Template.md
+          update_existing: true
+          search_existing: open
+      - name: Show issue URL
+        run: 'echo Created ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/Wiki_Update_Issue_Template.md
+++ b/.github/workflows/Wiki_Update_Issue_Template.md
@@ -1,0 +1,18 @@
+---
+name: Wiki Update
+about: Issue template for updates of the wiki
+title: 'Wiki Update'
+labels: 'Docs'
+assignees: ''
+---
+
+Number of commits  
+made to the Wiki in the last 24 hours: **{{ env.CommitCount }}**
+
+These are the details of the latest commit: 
+
+| Item  | Value  |
+|:---|:---|
+| Date | {{ env.UpdatedOn }} |
+| Hash | [{{ env.Hash }}](https://github.com/axuno/SmartFormat/wiki/_compare/{{ env.Hash }}) |
+| Message | {{ env.commitMessage }} |

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -7,16 +7,31 @@ using SmartFormat.Core.Extensions;
 
 namespace SmartFormat.Extensions;
 
+#if NET6_0_OR_GREATER
 /// <summary>
-/// Do the default formatting, same logic as "String.Format".
+/// Does the default formatting.
+/// This formatter in always required, unless you implement your own.
+/// <pre/>
+/// It supports <see cref="ISpanFormattable"/>, <see cref="IFormattable"/>, and <see cref="ICustomFormatter"/>.
 /// </summary>
+#else
+/// <summary>
+/// Does the default formatting.
+/// This formatter in always required, unless you implement your own.
+/// <pre/>
+/// It supports <see cref="IFormattable"/> and <see cref="ICustomFormatter"/>.
+/// </summary>
+#endif
 public class DefaultFormatter : IFormatter
 {
+
+#if NET6_0_OR_GREATER
     /// <summary>
     /// The maximum size of the stack-allocated buffer
-    /// for formatting <see cref="ISpanFormattable"/> objects.
+    /// for formatting <see cref="System.ISpanFormattable"/> objects.
     /// </summary>
     internal const int StackAllocCharBufferSize = 512;
+#endif
     
     /// <summary>
     /// Obsolete. <see cref="IFormatter"/>s only have one unique name.
@@ -68,7 +83,7 @@ public class DefaultFormatter : IFormatter
         if (current is ISpanFormattable spanFormattable)
         {
             // ISpanFormattable has the same speed as IFormattable,
-            // but brings less GC pressure (about 25% less for processing 1234567.890123f).
+            // but brings less GC pressure (e.g. 25% less for processing 1234567.890123f).
 
             var fmtTextSpan = format != null ? format.AsSpan() : Span<char>.Empty;
 

--- a/src/SmartFormat/Extensions/DefaultFormatter.cs
+++ b/src/SmartFormat/Extensions/DefaultFormatter.cs
@@ -13,10 +13,16 @@ namespace SmartFormat.Extensions;
 public class DefaultFormatter : IFormatter
 {
     /// <summary>
+    /// The maximum size of the stack-allocated buffer
+    /// for formatting <see cref="ISpanFormattable"/> objects.
+    /// </summary>
+    internal const int StackAllocCharBufferSize = 512;
+    
+    /// <summary>
     /// Obsolete. <see cref="IFormatter"/>s only have one unique name.
     /// </summary>
     [Obsolete("Use property \"Name\" instead", true)]
-    public string[] Names { get; set; } = {"default", "d", string.Empty};
+    public string[] Names { get; set; } = { "default", "d", string.Empty };
 
     ///<inheritdoc/>
     public string Name { get; set; } = "d";
@@ -42,37 +48,57 @@ public class DefaultFormatter : IFormatter
             return true;
         }
 
-        // Use the provider to see if a CustomFormatter is available:
-        var provider = formattingInfo.FormatDetails.Provider;
+        /* 
+         * The order of precedence is:
+         * 1. ICustomFormatter from the IFormatProvider
+         * 2. ISpanFormattable (for .NET 6.0 or later)
+         * 3. IFormattable
+         * 4. ToString
+         */
 
-        //  We will try using IFormatProvider, IFormattable, and if all else fails, ToString.
-        string? result; 
+        var provider = formattingInfo.FormatDetails.Provider;
         if (provider?.GetFormat(typeof(ICustomFormatter)) is ICustomFormatter cFormatter)
         {
             var formatText = format?.GetLiteralText();
-            result = cFormatter.Format(formatText, current, provider);
-        }
-        // IFormattable
-        // Note: This is what ValueStringBuilder is implementing in the same way
-        else if (current is IFormattable formattable)
-        {
-            var formatText = format?.ToString();
-            result = formattable.ToString(formatText, provider);
-        }
-        else if (current is string str)
-        {
-            formattingInfo.Write(str.AsSpan());
+            formattingInfo.Write(cFormatter.Format(formatText, current, provider).AsSpan());
             return true;
         }
-        // ToString:
-        else
+
+#if NET6_0_OR_GREATER
+        if (current is ISpanFormattable spanFormattable)
         {
-            result = current?.ToString();
+            // ISpanFormattable has the same speed as IFormattable,
+            // but brings less GC pressure (about 25% less for processing 1234567.890123f).
+
+            var fmtTextSpan = format != null ? format.AsSpan() : Span<char>.Empty;
+
+            // Try to use the stack buffer first
+            Span<char> buffer = stackalloc char[StackAllocCharBufferSize];
+
+            if (spanFormattable.TryFormat(buffer, out var written, fmtTextSpan, provider))
+            {
+                formattingInfo.Write(buffer.Slice(0, written));
+                return true;
+            }
+
+            // If the stack buffer is too small, use a heap buffer
+            using var arrayBuffer = new ZString.ZCharArray(2_000_000);
+            arrayBuffer.Write(spanFormattable, fmtTextSpan, provider);
+            formattingInfo.Write(arrayBuffer.GetSpan());
+            return true;
+        }
+#endif
+
+        if (current is IFormattable formattable)
+        {
+            var fmtTextString = format?.ToString();
+            formattingInfo.Write(formattable.ToString(fmtTextString, provider).AsSpan());
+            return true;
         }
 
-        // Output the result:
-        formattingInfo.Write(result != null ? result.AsSpan() : ReadOnlySpan<char>.Empty);
-
+        // Fallback to ToString (string.ToString() returns 'this')
+        var result = current != null ? current.ToString().AsSpan() : Span<char>.Empty;
+        formattingInfo.Write(result);
         return true;
     }
 }

--- a/src/SmartFormat/ZString/ZCharArray.cs
+++ b/src/SmartFormat/ZString/ZCharArray.cs
@@ -205,7 +205,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
 
-        // Increases the buffer size until its big enough
+        // Increases the buffer size until it's big enough
         while (true)
         {
             if (data.TryFormat(_bufferArray.AsSpan(_currentLength), out var written, format, provider))


### PR DESCRIPTION
Closes #422 

* Implement `ISpanFormattable` for `DefaultFormatter`
* Remove usage of stack buffer for `ISpanFormattable` in ZCharArray
* Make `IFormatProvider` an optional argument in `ZCharArray.Write(...)` overloads
* Add unit tests

```CSharp
// Performance test case
Smart.FormatInto(output, null, _placeholder0005Format, 1234567.890123f, 1234567.890123f, 1234567.890123f, 1234567.890123f, 1234567.890123f);
```
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3737/23H2/2023Update/SunValley3)
13th Gen Intel Core i7-13700K, 1 CPU, 24 logical and 16 physical cores
.NET SDK 8.0.302
  [Host]   : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX2
  .NET 8.0 : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX2

Job=.NET 8.0  Runtime=.NET 8.0

| Method                   | N     | Mean          | Error       | StdDev      | Ratio | RatioSD | Gen0       | Allocated    | Alloc Ratio |
|------------------------- |------ |--------------:|------------:|------------:|------:|--------:|-----------:|-------------:|------------:|
| ISpanFormattable         | 100   |     74.502 us |   0.3693 us |   0.3273 us |  8.52 |    0.05 |     4.0283 |      62.5 KB |        2.76 |
| IFormattable             | 100   |     77.927 us |   0.5760 us |   0.5388 us |  8.91 |    0.07 |     5.2490 |     82.03 KB |        3.62 |
```
ISpanFormattable is 5% faster than IFormattable, with 24% less allocations