### PR TITLE
Denial of Service Vulnerability in System.Text.Json < 8.0.4

### DIFF
--- a/src/SmartFormat.Extensions.System.Text.Json/SmartFormat.Extensions.System.Text.Json.csproj
+++ b/src/SmartFormat.Extensions.System.Text.Json/SmartFormat.Extensions.System.Text.Json.csproj
@@ -14,7 +14,7 @@ It uses extensions to provide named placeholders, localization, pluralization, g
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -15,13 +15,13 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
     </ItemGroup>
 


### PR DESCRIPTION
* Bump System.Text.Json to v8.0.4
* A vulnerability exists in .NET when calling the JsonSerializer.DeserializeAsyncEnumerable method against an untrusted input using System.Text.Json may result in Denial of Service.
* See details: https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

#### PR Classification
Dependency updates to ensure compatibility and stability.

#### PR Summary
Updated package versions to maintain compatibility and stability.
- `SmartFormat.Extensions.System.Text.Json.csproj`: Updated `System.Text.Json` from `8.0.3` to `8.0.4`.
- `SmartFormat.Tests.csproj`: Updated `Microsoft.NET.Test.Sdk` from `17.9.0` to `17.10.0` and `NUnit3TestAdapter` from `4.5.0` to `4.6.0`.
