### PR TITLE
Update dependencies in SmartFormat.Tests

### DIFF
--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -15,14 +15,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.1" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Updated the following NuGet packages:
- Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.1
- NUnit from 4.1.0 to 4.2.2
- NUnit.Analyzers from 4.2.0 to 4.3.0
- FluentAssertions from 6.12.0 to 6.12.1

These updates include bug fixes, performance improvements, and new features.