### PR TITLE
Bump version to v3.5.2

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -17,8 +17,8 @@ jobs:
     # (PRs from forks can't access secrets other than secrets.GITHUB_TOKEN for security reasons)
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
-      version: '3.5.1'
-      versionFile: '3.5.1'
+      version: '3.5.2'
+      versionFile: '3.5.2'
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ for:
       - ps: dotnet restore SmartFormat.sln --verbosity quiet
       - ps: dotnet add .\SmartFormat.Tests\SmartFormat.Tests.csproj package AltCover
       - ps: |
-          $version = "3.5.1"
+          $version = "3.5.2"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) SmartFormat Project</Copyright>
         <RepositoryUrl>https://github.com/axuno/SmartFormat.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>3.5.1</Version>
-        <FileVersion>3.5.1</FileVersion>
+        <Version>3.5.2</Version>
+        <FileVersion>3.5.2</FileVersion>
         <AssemblyVersion>3.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/SmartFormat.Tests/Extensions/IsMatchFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/IsMatchFormatterTests.cs
@@ -140,7 +140,7 @@ public class IsMatchFormatterTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(EscapedLiteral.EscapeCharLiterals('\\', regExEscaped, 0, regExEscaped.Length, true), Is.EqualTo(optionsEscaped));
+            Assert.That(EscapedLiteral.EscapeCharLiterals('\\', regExEscaped, 0, regExEscaped.Length, true), Is.EquivalentTo(optionsEscaped));
             Assert.That(regEx.Match(search).Success, Is.True);
         });
 

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit" Version="4.3.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Bump version to v3.5.2
* Update NUnit v4.2.2 to v4.3.0
   Fix unit test that was using `Is.EqualTo` instead of `Is.EquivalentTo` for an `IEnumerable` object
