### PR TITLE
Add support for specifying separator between units when using TimeFormatter

### DIFF
--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
@@ -49,10 +49,27 @@ public static class TimeSpanUtility
     public static string ToTimeString(this TimeSpan fromTime, TimeSpanFormatOptions options,
         TimeTextInfo timeTextInfo)
     {
+        return string.Join(" ", fromTime.ToTimeParts(options, timeTextInfo));
+    }
+
+    /// <summary>
+    /// <para>Turns a TimeSpan into a list of human-readable text parts.</para>
+    /// <para>Uses the specified timeSpanFormatOptions.</para>
+    /// <para>For example: "31.23:59:00.555" = "31 days 23 hours 59 minutes 0 seconds 555 milliseconds"</para>
+    /// </summary>
+    /// <param name="fromTime"></param>
+    /// <param name="options">
+    /// <para>A combination of flags that determine the formatting options.</para>
+    /// <para>These will be combined with the default timeSpanFormatOptions.</para>
+    /// </param>
+    /// <param name="timeTextInfo">An object that supplies the text to use for output</param>
+    public static IList<string> ToTimeParts(this TimeSpan fromTime, TimeSpanFormatOptions options,
+        TimeTextInfo timeTextInfo)
+    {
         // If there are any missing options, merge with the defaults:
         // Also, as a safeguard against missing DefaultFormatOptions, let's also merge with the AbsoluteDefaults:
         options = options.Merge(DefaultFormatOptions).Merge(AbsoluteDefaults);
-            
+
         // Extract the individual options:
         var rangeMax = options.Mask(TimeSpanFormatOptionsPresets.Range).AllFlags().Last();
         _rangeMin = options.Mask(TimeSpanFormatOptionsPresets.Range).AllFlags().First();
@@ -134,16 +151,7 @@ public static class TimeSpanUtility
             }
         }
 
-        var resultString = new StringBuilder();
-        for (var i = 0; i < result.Count; i++)
-        {
-            if (i > 0)
-                resultString.Append(_timeTextInfo.GetSeparatorText(i, result.Count));
-
-            resultString.Append(result[i]);
-        }
-
-        return resultString.ToString();
+        return result;
     }
 
     private static bool ShouldTruncate(int value, bool textStarted, out bool displayThisValue)

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeSpanUtility.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -84,8 +85,7 @@ public static class TimeSpanUtility
         }
 
         // Create our result:
-        var textStarted = false;
-        var result = new StringBuilder();
+        var result = new List<string>();
         for (var i = rangeMax; i >= _rangeMin; i = (TimeSpanFormatOptions) ((int) i >> 1))
         {
             // Determine the value and title:
@@ -122,21 +122,28 @@ public static class TimeSpanUtility
             }
 
             //Determine whether to display this value
-            if (!ShouldTruncate(value, textStarted, out var displayThisValue)) continue;
+            if (!ShouldTruncate(value, result.Any(), out var displayThisValue)) continue;
 
-            PrepareOutput(value, i == _rangeMin, textStarted, result, ref displayThisValue);
+            PrepareOutput(value, i == _rangeMin, result.Any(), result, ref displayThisValue);
 
             // Output the value:
             if (displayThisValue)
             {
-                if (textStarted) result.Append(' ');
                 var unitTitle = _timeTextInfo.GetUnitText(i, value, _abbreviate);
-                result.Append(unitTitle);
-                textStarted = true;
+                if (!string.IsNullOrEmpty(unitTitle)) result.Add(unitTitle);
             }
         }
 
-        return result.ToString();
+        var resultString = new StringBuilder();
+        for (var i = 0; i < result.Count; i++)
+        {
+            if (i > 0)
+                resultString.Append(_timeTextInfo.GetSeparatorText(i, result.Count));
+
+            resultString.Append(result[i]);
+        }
+
+        return resultString.ToString();
     }
 
     private static bool ShouldTruncate(int value, bool textStarted, out bool displayThisValue)
@@ -163,7 +170,7 @@ public static class TimeSpanUtility
         return false;
     }
 
-    private static void PrepareOutput(int value, bool isRangeMin, bool hasTextStarted, StringBuilder result, ref bool displayThisValue)
+    private static void PrepareOutput(int value, bool isRangeMin, bool hasTextStarted, List<string> result, ref bool displayThisValue)
     {
         // we need to display SOMETHING (even if it's zero)
         if (isRangeMin && !hasTextStarted)
@@ -173,7 +180,7 @@ public static class TimeSpanUtility
             {
                 // Output the "less than 1 unit" text:
                 var unitTitle = _timeTextInfo!.GetUnitText(_rangeMin, 1, _abbreviate);
-                result.Append(_timeTextInfo.GetLessThanText(unitTitle));
+                result.Add(_timeTextInfo.GetLessThanText(unitTitle));
                 displayThisValue = false;
             }
         }

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeTextInfo.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeTextInfo.cs
@@ -83,6 +83,23 @@ public class TimeTextInfo
     /// </summary>
     public string[] Ptxt_week { get; set;} = Array.Empty<string>();
 
+    /// <summary>
+    /// Text for separator between units.
+    /// First value is for the separator between the last two units (and also if only two units are present).
+    ///
+    /// eg.
+    /// [" and", ", "] would result in "1 day, 10 minutes and 10 seconds"
+    /// </summary>
+    public string[] Ptxt_separator { get; set; } = Array.Empty<string>();
+
+    public virtual string GetSeparatorText(int currentIndex, int unitCount)
+    {
+        if (Ptxt_separator.Length == 0) return " ";
+        if (Ptxt_separator.Length == 1 || unitCount == 2) return Ptxt_separator[0];
+
+        return Ptxt_separator[currentIndex + 1 == unitCount ? 0 : 1];
+    }
+
     private static string GetValue(PluralRules.PluralRuleDelegate pluralRule, int value, IReadOnlyList<string> units)
     {
         // Get the plural index from the plural rule,

--- a/src/SmartFormat.Extensions.Time/Utilities/TimeTextInfo.cs
+++ b/src/SmartFormat.Extensions.Time/Utilities/TimeTextInfo.cs
@@ -83,23 +83,6 @@ public class TimeTextInfo
     /// </summary>
     public string[] Ptxt_week { get; set;} = Array.Empty<string>();
 
-    /// <summary>
-    /// Text for separator between units.
-    /// First value is for the separator between the last two units (and also if only two units are present).
-    ///
-    /// eg.
-    /// [" and", ", "] would result in "1 day, 10 minutes and 10 seconds"
-    /// </summary>
-    public string[] Ptxt_separator { get; set; } = Array.Empty<string>();
-
-    public virtual string GetSeparatorText(int currentIndex, int unitCount)
-    {
-        if (Ptxt_separator.Length == 0) return " ";
-        if (Ptxt_separator.Length == 1 || unitCount == 2) return Ptxt_separator[0];
-
-        return Ptxt_separator[currentIndex + 1 == unitCount ? 0 : 1];
-    }
-
     private static string GetValue(PluralRules.PluralRuleDelegate pluralRule, int value, IReadOnlyList<string> units)
     {
         // Get the plural index from the plural rule,

--- a/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
@@ -12,6 +12,15 @@ namespace SmartFormat.Tests.Extensions;
 [TestFixture]
 public class TimeFormatterTests
 {
+    private const string SeparatorLanguage = "zu";
+    static TimeFormatterTests()
+    {
+
+        var englishWithSeparator = CommonLanguagesTimeTextInfo.English;
+        englishWithSeparator.Ptxt_separator = new[] { " and ", ", " };
+        CommonLanguagesTimeTextInfo.AddLanguage(SeparatorLanguage, englishWithSeparator);
+    }
+
     private static SmartFormatter GetFormatter()
     {
         var smart = Smart.CreateDefaultSmartFormat(new SmartSettings
@@ -129,6 +138,20 @@ public class TimeFormatterTests
     [TestCase("{4:time:}","de", "weniger als 1 Sekunde")]
     [TestCase("{5:time:}", "de", "5 Tage")]
     public void Test_Defaults(string format, string language, string expected)
+    {
+        var args = GetArgs();
+        var smart = GetFormatter();
+        var actual = smart.Format(CultureInfo.GetCultureInfo(language), format, args);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [TestCase("{0:time:}", SeparatorLanguage, "less than 1 second")]
+    [TestCase("{1:time:}", SeparatorLanguage, "1 day, 1 hour, 1 minute and 1 second")]
+    [TestCase("{2:time:}", SeparatorLanguage, "2 hours and 2 seconds")]
+    [TestCase("{3:time:}", SeparatorLanguage, "3 days and 3 seconds")]
+    [TestCase("{4:time:}", SeparatorLanguage, "less than 1 second")]
+    [TestCase("{5:time:}", SeparatorLanguage, "5 days")]
+    public void Test_English_Separator(string format, string language, string expected)
     {
         var args = GetArgs();
         var smart = GetFormatter();

--- a/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions.Time/TimeFormatterTests.cs
@@ -5,6 +5,7 @@ using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
 using SmartFormat.Extensions;
 using SmartFormat.Extensions.Time.Utilities;
+using SmartFormat.Tests.TestUtils;
 using SmartFormat.Utilities;
 
 namespace SmartFormat.Tests.Extensions;
@@ -12,15 +13,6 @@ namespace SmartFormat.Tests.Extensions;
 [TestFixture]
 public class TimeFormatterTests
 {
-    private const string SeparatorLanguage = "zu";
-    static TimeFormatterTests()
-    {
-
-        var englishWithSeparator = CommonLanguagesTimeTextInfo.English;
-        englishWithSeparator.Ptxt_separator = new[] { " and ", ", " };
-        CommonLanguagesTimeTextInfo.AddLanguage(SeparatorLanguage, englishWithSeparator);
-    }
-
     private static SmartFormatter GetFormatter()
     {
         var smart = Smart.CreateDefaultSmartFormat(new SmartSettings
@@ -111,11 +103,18 @@ public class TimeFormatterTests
         Assert.That(() => smart.Format("{0:time:}", DateTime.UtcNow), Throws.Exception.TypeOf<FormattingException>());
     }
 
-    [Test]
-    public void Formatter_With_NestedFormat_Should_Throw()
+    [TestCase("{0:time: {:list:|, | and }}", "en", "less than 1 second")]
+    [TestCase("{1:time: {:list:|, | and }}", "en", "1 day, 1 hour, 1 minute and 1 second")]
+    [TestCase("{2:time: {:list:|, | and }}", "en", "2 hours and 2 seconds")]
+    [TestCase("{3:time: {:list:|, | and }}", "en", "3 days and 3 seconds")]
+    [TestCase("{4:time: {:list:|, | and }}", "en", "less than 1 second")]
+    [TestCase("{5:time: {:list:|, | and }}", "en", "5 days")]
+    public void NestedListFormatTest(string format, string language, string expected)
     {
+        var args = GetArgs();
         var smart = GetFormatter();
-        Assert.That(() => smart.Format("{0:time:{}}", DateTime.UtcNow), Throws.Exception.TypeOf<FormattingException>());
+        var actual = smart.Format(CultureInfo.GetCultureInfo(language), format, args);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -138,20 +137,6 @@ public class TimeFormatterTests
     [TestCase("{4:time:}","de", "weniger als 1 Sekunde")]
     [TestCase("{5:time:}", "de", "5 Tage")]
     public void Test_Defaults(string format, string language, string expected)
-    {
-        var args = GetArgs();
-        var smart = GetFormatter();
-        var actual = smart.Format(CultureInfo.GetCultureInfo(language), format, args);
-        Assert.That(actual, Is.EqualTo(expected));
-    }
-
-    [TestCase("{0:time:}", SeparatorLanguage, "less than 1 second")]
-    [TestCase("{1:time:}", SeparatorLanguage, "1 day, 1 hour, 1 minute and 1 second")]
-    [TestCase("{2:time:}", SeparatorLanguage, "2 hours and 2 seconds")]
-    [TestCase("{3:time:}", SeparatorLanguage, "3 days and 3 seconds")]
-    [TestCase("{4:time:}", SeparatorLanguage, "less than 1 second")]
-    [TestCase("{5:time:}", SeparatorLanguage, "5 days")]
-    public void Test_English_Separator(string format, string language, string expected)
     {
         var args = GetArgs();
         var smart = GetFormatter();


### PR DESCRIPTION
Implementation of #458.
Since many languages needs to know if it is the last item/unit in the list in order to choose the correct separator, I had to change from using the `StringBuilder` to first build a list of the items/unit outputs and then combine them.