### PR TITLE
Make `SmartFormatter.Format(...)` methods thread-safe

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ChooseFormatterTests.cs
@@ -1,4 +1,9 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Core.Settings;
@@ -172,5 +177,47 @@ public class ChooseFormatterTests
             Assert.That(result1, Is.EqualTo("umlautA"));
             Assert.That(result2, Is.EqualTo("umlautA"));
         });
+    }
+
+    [Test]
+    public void Parallel_ChooseFormatter()
+    {
+        // Switch to thread safety - otherwise the test would throw an InvalidOperationException
+        var savedMode = ThreadSafeMode.SwitchOn();
+
+        var results = new ConcurrentDictionary<long, string>();
+        var threadIds = new ConcurrentDictionary<int, int>();
+        var options = new ParallelOptions { MaxDegreeOfParallelism = 100 };
+        long resultCounter = 0;
+
+        // One instance for all threads
+        var smart = new SmartFormatter().AddExtensions(new DefaultSource())
+            .AddExtensions(new DefaultFormatter(), new ChooseFormatter());
+
+        Assert.That(code: () =>
+            Parallel.For(0L, 1000, options, (i, loopState) =>
+            {
+                // register unique thread ids
+                threadIds.TryAdd(Environment.CurrentManagedThreadId, Environment.CurrentManagedThreadId);
+
+                // Re-use the same SmartFormatter instance, where the Format method is thread-safe.
+                results.TryAdd(i, smart.Format("{0:D3} {1:choose(1|2|3):one|two|three|default}", i, 2));
+                Interlocked.Increment(ref resultCounter);
+            }), Throws.Nothing);
+
+        var sortedResult = results.OrderBy(r => r.Value).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(threadIds, Has.Count.AtLeast(2)); // otherwise the test is not significant
+            Assert.That(results, Has.Count.EqualTo(resultCounter));
+            for (var i = 0; i < resultCounter; i++)
+            {
+                Assert.That(sortedResult[i].Value, Is.EqualTo(i.ToString("D3") + " two"));
+            }
+        });
+
+        // Restore to saved value
+        ThreadSafeMode.SwitchTo(savedMode);
     }
 }

--- a/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ConditionalFormatterTests.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
 using SmartFormat.Extensions;
@@ -182,5 +186,47 @@ public class ConditionalFormatterTests
         {
             CultureInfo.CurrentCulture = currentCulture;
         }
+    }
+
+    [Test]
+    public void Parallel_ConditionalFormatter()
+    {
+        // Switch to thread safety - otherwise the test would throw an InvalidOperationException
+        var savedMode = ThreadSafeMode.SwitchOn();
+
+        var results = new ConcurrentDictionary<long, string>();
+        var threadIds = new ConcurrentDictionary<int, int>();
+        var options = new ParallelOptions { MaxDegreeOfParallelism = 100 };
+        long resultCounter = 0;
+
+        // One instance for all threads
+        var smart = new SmartFormatter().AddExtensions(new DefaultSource())
+            .AddExtensions(new DefaultFormatter(), new ConditionalFormatter());
+
+        Assert.That(code: () =>
+            Parallel.For(0L, 1000, options, (i, loopState) =>
+            {
+                // register unique thread ids
+                threadIds.TryAdd(Environment.CurrentManagedThreadId, Environment.CurrentManagedThreadId);
+
+                // Re-use the same SmartFormatter instance, where the Format method is thread-safe.
+                results.TryAdd(i, smart.Format("{0:D3} {1:cond:Yes|No}", i, false));
+                Interlocked.Increment(ref resultCounter);
+            }), Throws.Nothing);
+
+        var sortedResult = results.OrderBy(r => r.Value).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(threadIds, Has.Count.AtLeast(2)); // otherwise the test is not significant
+            Assert.That(results, Has.Count.EqualTo(resultCounter));
+            for (var i = 0; i < resultCounter; i++)
+            {
+                Assert.That(sortedResult[i].Value, Is.EqualTo(i.ToString("D3") + " No"));
+            }
+        });
+
+        // Restore to saved value
+        ThreadSafeMode.SwitchTo(savedMode);
     }
 }

--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SmartFormat.Core.Formatting;
@@ -314,5 +316,47 @@ public class ListFormatterTests
         Assert.That(() => smart.Format(">{Numbers[0]}<", data),
             Throws.Exception.TypeOf<FormattingException>().And.Message
                 .Contains("{Numbers[0]}"));
+    }
+
+    [Test]
+    public void Parallel_ListFormatter()
+    {
+        // Switch to thread safety - otherwise the test would throw an InvalidOperationException
+        var savedMode = ThreadSafeMode.SwitchOn();
+
+        var results = new ConcurrentDictionary<long, string>();
+        var threadIds = new ConcurrentDictionary<int, int>();
+        var options = new ParallelOptions { MaxDegreeOfParallelism = 100 };
+        long resultCounter = 0;
+
+        // One instance for all threads
+        var smart = new SmartFormatter().AddExtensions(new DefaultSource())
+            .AddExtensions(new DefaultFormatter(), new ListFormatter());
+
+        Assert.That(code: () =>
+            Parallel.For(0L, 1000, options, (i, loopState) =>
+            {
+                // register unique thread ids
+                threadIds.TryAdd(Environment.CurrentManagedThreadId, Environment.CurrentManagedThreadId);
+
+                // Re-use the same SmartFormatter instance, where the Format method is thread-safe.
+                results.TryAdd(i, smart.Format("{0:D3} {1:list:{}|-}", i, new[] { 1, 2, 3 }));
+                Interlocked.Increment(ref resultCounter);
+            }), Throws.Nothing);
+
+        var sortedResult = results.OrderBy(r => r.Value).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(threadIds, Has.Count.AtLeast(2)); // otherwise the test is not significant
+            Assert.That(results, Has.Count.EqualTo(resultCounter));
+            for (var i = 0; i < resultCounter; i++)
+            {
+                Assert.That(sortedResult[i].Value, Is.EqualTo(i.ToString("D3") + " 1-2-3"));
+            }
+        });
+
+        // Restore to saved value
+        ThreadSafeMode.SwitchTo(savedMode);
     }
 }

--- a/src/SmartFormat/Core/Parsing/Parser.cs
+++ b/src/SmartFormat/Core/Parsing/Parser.cs
@@ -12,6 +12,12 @@ namespace SmartFormat.Core.Parsing;
 
 /// <summary>
 /// Parses a format string.
+/// <para/>
+/// <para>
+/// <b>Thread-safety</b>:<br/>
+/// The <see cref="ParseFormat"/> method is thread-safe.
+/// Other methods (e.g. changing SmartSettings or other properties) is not thread-safe.
+/// </para>
 /// </summary>
 public class Parser
 {
@@ -147,6 +153,8 @@ public class Parser
 
     /// <summary>
     /// Parses a format string. This method is thread-safe.
+    /// <para/>
+    /// Changing the <see cref="Settings"/> or properties is not thread-safe.
     /// </summary>
     /// <param name="inputFormat"></param>
     /// <returns>The <see cref="Format"/> for the parsed string.</returns>

--- a/src/SmartFormat/Smart.cs
+++ b/src/SmartFormat/Smart.cs
@@ -14,16 +14,22 @@ namespace SmartFormat;
 /// The default instance has all extensions registered.
 /// <para>For optimized performance, create a <see cref="SmartFormatter"/> instance and register the
 /// particular extensions that are needed.</para>
-/// <para><see cref="Smart"/> methods are not thread safe.</para>
+/// <para>
+/// <b>Thread-safety</b>:<br/>
+/// <see cref="Smart"/>.Format methods are thread-safe when <see cref="SmartSettings.IsThreadSafeMode"/> is <see langword="true"/>.
+/// Other methods (e.g. AddExtensions, changing SmartSettings) are not thread-safe.
+/// </para>
 /// </summary>
 public static class Smart
 {
     /// <summary>
-    /// Creates isolated versions of the formatter in each thread.
-    /// This is required, because even if Smart.Default.Format(string, object?[]) is thread-safe,
-    /// other methods like Smart.Default.Extensions.Remove(...) are not.
+    /// A <see cref="SmartFormatter"/> instance with core extensions registered.
+    /// <para>
+    /// <b>Thread-safety</b>:<br/>
+    /// <see cref="Smart"/>.Format methods are thread-safe when <see cref="SmartSettings.IsThreadSafeMode"/> is <see langword="true"/>.
+    /// Other methods (e.g. AddExtensions, changing SmartSettings) are not thread-safe.
+    /// </para>
     /// </summary>
-    [ThreadStatic]
     private static SmartFormatter? _formatter;
 
     #region: Smart.Format :
@@ -68,7 +74,7 @@ public static class Smart
     /// <returns>The format items in the specified format string replaced with the string representation or the corresponding object.</returns>
     public static string Format(string format, object? arg0, object? arg1, object? arg2)
     {
-        return Default.Format(format,  arg0, arg1, arg2);
+        return Default.Format(format, arg0, arg1, arg2);
     }
 
     /// <summary>
@@ -103,24 +109,20 @@ public static class Smart
     /// <summary>
     /// Gets or sets the default <see cref="SmartFormatter"/>.
     /// If not set, the <see cref="CreateDefaultSmartFormat"/> will be used.
-    /// <para>
-    /// Using the <see cref="ThreadStaticAttribute"/>, <see cref="Default"/> returns isolated instances of the <see cref="SmartFormatter"/> in each thread.
-    /// </para>
-    /// <para>
-    /// It is recommended to set the thread-<see langword="static"/>
-    /// <see cref="Default"/> <see cref="SmartFormatter"/> with the extensions that are actually needed.
-    /// As <see cref="Default"/> is thread-static, this must be done on each thread.
-    /// </para>
+    /// <para/>
+    /// It is recommended to set the <see cref="Default"/> <see cref="SmartFormatter"/> with the extensions that are actually needed.
     /// </summary>
     public static SmartFormatter Default
     {
         get
         {
-            // formatter was not yet in use on current thread
             _formatter ??= CreateDefaultSmartFormat();
             return _formatter;
         }
-        set => _formatter = value;
+        set
+        {
+            _formatter = value;
+        }
     }
 
     /// <summary>

--- a/src/SmartFormat/SmartFormatter.cs
+++ b/src/SmartFormat/SmartFormatter.cs
@@ -18,11 +18,21 @@ namespace SmartFormat;
 /// <summary>
 /// This class contains the Format method that constructs
 /// the composite string by invoking each extension.
+/// <para>
+/// <b>Thread-safety</b>:<br/>
+/// <see cref="Smart"/>.Format methods are thread-safe when <see cref="SmartSettings.IsThreadSafeMode"/> is <see langword="true"/>.
+/// Other methods (e.g. AddExtensions, changing SmartSettings) are not thread-safe.
+/// </para>
 /// </summary>
 public class SmartFormatter
 {
     /// <summary>
     /// Creates a new instance of a <see cref="SmartFormatter"/>.
+    /// <para>
+    /// <b>Thread-safety</b>:<br/>
+    /// <see cref="Smart"/>.Format methods are thread-safe when <see cref="SmartSettings.IsThreadSafeMode"/> is <see langword="true"/>.
+    /// Other methods (e.g. AddExtensions, changing SmartSettings) are not thread-safe.
+    /// </para>
     /// </summary>
     /// <param name="settings">
     /// The <see cref="SmartSettings"/> to use, or <see langword="null"/> for default settings.


### PR DESCRIPTION
- Removed `ThreadStatic` attribute from the `Smart.Default` instance of `SmartFormatter`.
- Added `Parallel` unit tests ensuring thread-safe operations with shared `SmartFormatter` instances with different `Smart.Extensions`.
- Updated documentation in `Parser.cs`, `Smart.cs`, and `SmartFormatter.cs` to clarify thread safety of methods.
