### PR TITLE
Make `Publish` workflow branch-agnostic

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -19,6 +19,11 @@ jobs:
     outputs:
       VERSION: ${{ steps.set_version.outputs.VERSION }}
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for all tags and branches
+
     - name: Verify tag exists
       run: |
         git fetch --tags --quiet


### PR DESCRIPTION
This change makes the workflow branch-agnostic and ensures we are building exactly what the version tag points to, regardless of which branch it was created from. It removes the former limitation to the `main` branch.