### PR TITLE
Clear pool buffer array on disposal in `ZCharArray`

### DIFF
--- a/src/SmartFormat/ZString/ZCharArray.cs
+++ b/src/SmartFormat/ZString/ZCharArray.cs
@@ -20,9 +20,8 @@ public struct ZCharArray : IDisposable
     private static readonly ArrayPool<char>
         Pool = ArrayPool<char>.Create(MaxBufferCapacity, 100);
 
-    private char[] _bufferArray;
+    private char[]? _bufferArray;
     private int _currentLength;
-    private bool _isDisposed;
 
     /// <summary>
     /// The default capacity of the array.
@@ -49,7 +48,6 @@ public struct ZCharArray : IDisposable
     {
         _bufferArray = Pool.Rent(length);
         _currentLength = 0;
-        _isDisposed = false;
     }
 
     /// <summary>
@@ -98,7 +96,7 @@ public struct ZCharArray : IDisposable
         get
         {
             ThrowIfDisposed();
-            return _bufferArray.Length;
+            return _bufferArray!.Length;
         }
     }
 
@@ -121,8 +119,8 @@ public struct ZCharArray : IDisposable
     private void Grow(int length)
     {
         var newArray = Pool.Rent(length);
-        Array.Copy(_bufferArray, newArray, Math.Min(_bufferArray.Length, length));
-        Pool.Return(_bufferArray);
+        Array.Copy(_bufferArray!, newArray, Math.Min(_bufferArray!.Length, length));
+        Pool.Return(_bufferArray, clearArray: true);
         _bufferArray = newArray;
     }
 
@@ -135,7 +133,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
+        data.CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -148,7 +146,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
+        data.CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -161,7 +159,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.AsSpan().CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
+        data.AsSpan().CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -174,7 +172,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(1);
-        _bufferArray[_currentLength++] = c;
+        _bufferArray![_currentLength++] = c;
     }
 
     /// <summary>
@@ -190,7 +188,7 @@ public struct ZCharArray : IDisposable
 
         for (var i = 0; i < count; i++)
         {
-            _bufferArray[_currentLength++] = c;
+            _bufferArray![_currentLength++] = c;
         }
     }
 
@@ -248,7 +246,7 @@ public struct ZCharArray : IDisposable
     /// <summary>
     /// Returns <see langword="true"/> if the array has been disposed.
     /// </summary>
-    public bool IsDisposed => _isDisposed;
+    public bool IsDisposed => _bufferArray is null;
 
     private void ThrowIfDisposed()
     {
@@ -263,7 +261,7 @@ public struct ZCharArray : IDisposable
     public override string ToString()
     {
         ThrowIfDisposed();
-        return new string(_bufferArray, 0, _currentLength);
+        return new string(_bufferArray!, 0, _currentLength);
     }
 
     /// <summary>
@@ -271,7 +269,7 @@ public struct ZCharArray : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_isDisposed) return;
+        if (IsDisposed) return;
 
         Pool.Return(_bufferArray!, clearArray: true);
         _bufferArray = null;

--- a/src/SmartFormat/ZString/ZCharArray.cs
+++ b/src/SmartFormat/ZString/ZCharArray.cs
@@ -20,8 +20,9 @@ public struct ZCharArray : IDisposable
     private static readonly ArrayPool<char>
         Pool = ArrayPool<char>.Create(MaxBufferCapacity, 100);
 
-    private char[]? _bufferArray;
+    private char[] _bufferArray;
     private int _currentLength;
+    private bool _isDisposed;
 
     /// <summary>
     /// The default capacity of the array.
@@ -48,6 +49,7 @@ public struct ZCharArray : IDisposable
     {
         _bufferArray = Pool.Rent(length);
         _currentLength = 0;
+        _isDisposed = false;
     }
 
     /// <summary>
@@ -96,7 +98,7 @@ public struct ZCharArray : IDisposable
         get
         {
             ThrowIfDisposed();
-            return _bufferArray!.Length;
+            return _bufferArray.Length;
         }
     }
 
@@ -119,7 +121,7 @@ public struct ZCharArray : IDisposable
     private void Grow(int length)
     {
         var newArray = Pool.Rent(length);
-        Array.Copy(_bufferArray!, newArray, Math.Min(_bufferArray!.Length, length));
+        Array.Copy(_bufferArray, newArray, Math.Min(_bufferArray.Length, length));
         Pool.Return(_bufferArray);
         _bufferArray = newArray;
     }
@@ -133,7 +135,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
+        data.CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -146,7 +148,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
+        data.CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -159,7 +161,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(data.Length);
-        data.AsSpan().CopyTo(_bufferArray!.AsSpan(_currentLength, data.Length));
+        data.AsSpan().CopyTo(_bufferArray.AsSpan(_currentLength, data.Length));
         _currentLength += data.Length;
     }
 
@@ -172,7 +174,7 @@ public struct ZCharArray : IDisposable
     {
         ThrowIfDisposed();
         GrowBufferIfNeeded(1);
-        _bufferArray![_currentLength++] = c;
+        _bufferArray[_currentLength++] = c;
     }
 
     /// <summary>
@@ -188,7 +190,7 @@ public struct ZCharArray : IDisposable
 
         for (var i = 0; i < count; i++)
         {
-            _bufferArray![_currentLength++] = c;
+            _bufferArray[_currentLength++] = c;
         }
     }
 
@@ -246,7 +248,7 @@ public struct ZCharArray : IDisposable
     /// <summary>
     /// Returns <see langword="true"/> if the array has been disposed.
     /// </summary>
-    public bool IsDisposed => _bufferArray is null;
+    public bool IsDisposed => _isDisposed;
 
     private void ThrowIfDisposed()
     {
@@ -261,7 +263,7 @@ public struct ZCharArray : IDisposable
     public override string ToString()
     {
         ThrowIfDisposed();
-        return new string(_bufferArray!, 0, _currentLength);
+        return new string(_bufferArray, 0, _currentLength);
     }
 
     /// <summary>
@@ -269,9 +271,9 @@ public struct ZCharArray : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (IsDisposed) return;
+        if (_isDisposed) return;
 
-        Pool.Return(_bufferArray!);
-        _bufferArray = null;
+        Pool.Return(_bufferArray, clearArray: true);
+        _isDisposed = true;
     }
 }

--- a/src/SmartFormat/ZString/ZCharArray.cs
+++ b/src/SmartFormat/ZString/ZCharArray.cs
@@ -273,7 +273,7 @@ public struct ZCharArray : IDisposable
     {
         if (_isDisposed) return;
 
-        Pool.Return(_bufferArray, clearArray: true);
-        _isDisposed = true;
+        Pool.Return(_bufferArray!, clearArray: true);
+        _bufferArray = null;
     }
 }


### PR DESCRIPTION
`ZCharArray` now ensures the buffer is always returned to the pool with `clearArray: true`.